### PR TITLE
fix: show token issuer as single localized label

### DIFF
--- a/public/locales/ar/network-page.json
+++ b/public/locales/ar/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "التبادلات",
   "exchangesLoadFailed": "خطأ: فشل في تحميل التبادلات. يرجى تحديث الصفحة أو المحاولة لاحقًا.",
   "token": "رمز",
+  "tokenIssuer": "{{name}} المُصدر",
   "tokens": "رموز",
   "smartContract": "عقد ذكي",
   "smartContracts": "العقود الذكية",

--- a/public/locales/de/network-page.json
+++ b/public/locales/de/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Börsen",
   "exchangesLoadFailed": "Fehler: Laden der Börsen fehlgeschlagen. Bitte aktualisieren Sie die Seite oder versuchen Sie es später erneut.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Emittent",
   "tokens": "Token",
   "smartContract": "Smart Contract",
   "smartContracts": "Smart Contracts",

--- a/public/locales/en/network-page.json
+++ b/public/locales/en/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Exchanges",
   "exchangesLoadFailed": "Error: Failed to load exchanges. Please refresh the page or try again later.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Issuer",
   "tokens": "Tokens",
   "smartContract": "Smart Contract",
   "smartContracts": "Smart Contracts",

--- a/public/locales/es/network-page.json
+++ b/public/locales/es/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Intercambios",
   "exchangesLoadFailed": "Error: No se pudieron cargar los intercambios. Por favor, actualiza la página o inténtalo de nuevo más tarde.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Emisor",
   "tokens": "Tokens",
   "smartContract": "Contrato inteligente",
   "smartContracts": "Contratos inteligentes",

--- a/public/locales/fr/network-page.json
+++ b/public/locales/fr/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Échanges",
   "exchangesLoadFailed": "Erreur : Échec du chargement des échanges. Veuillez actualiser la page ou réessayer plus tard.",
   "token": "Jeton",
+  "tokenIssuer": "{{name}} Émetteur",
   "tokens": "Jetons",
   "smartContract": "Contrat intelligent",
   "smartContracts": "Contrats intelligents",

--- a/public/locales/ja/network-page.json
+++ b/public/locales/ja/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "取引所",
   "exchangesLoadFailed": "エラー: 取引所の読み込みに失敗しました。ページを更新するか、後でもう一度お試しください。",
   "token": "トークン",
+  "tokenIssuer": "{{name}} 発行者",
   "tokens": "トークン",
   "smartContract": "スマートコントラクト",
   "smartContracts": "スマートコントラクト",

--- a/public/locales/nl/network-page.json
+++ b/public/locales/nl/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Beurzen",
   "exchangesLoadFailed": "Fout: Het laden van beurzen is mislukt. Vernieuw de pagina of probeer het later opnieuw.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Uitgever",
   "tokens": "Tokens",
   "smartContract": "Slim contract",
   "smartContracts": "Slimme Contracten",

--- a/public/locales/pt/network-page.json
+++ b/public/locales/pt/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Câmbios",
   "exchangesLoadFailed": "Erro: Falha ao carregar as câmbios. Por favor, atualize a página ou tente novamente mais tarde.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Emissor",
   "tokens": "Tokens",
   "smartContract": "Contrato Inteligente",
   "smartContracts": "Contratos Inteligentes",

--- a/public/locales/ru/network-page.json
+++ b/public/locales/ru/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Биржи",
   "exchangesLoadFailed": "Ошибка: Не удалось загрузить биржи. Обновите страницу или попробуйте позже.",
   "token": "Токен",
+  "tokenIssuer": "{{name}} Эмитент",
   "tokens": "Токены",
   "smartContract": "Смарт-контракт",
   "smartContracts": "Смарт-контракты",

--- a/public/locales/tr/network-page.json
+++ b/public/locales/tr/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Borsalar",
   "exchangesLoadFailed": "Hata: Borsalar yüklenemedi. Lütfen sayfayı yenileyin veya daha sonra tekrar deneyin.",
   "token": "Jeton",
+  "tokenIssuer": "{{name}} Yayımlayan",
   "tokens": "Jetonlar",
   "smartContract": "Akıllı Sözleşme",
   "smartContracts": "Akıllı Sözleşmeler",

--- a/public/locales/vi/network-page.json
+++ b/public/locales/vi/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "Các sàn giao dịch",
   "exchangesLoadFailed": "Lỗi: Không tải được danh sách sàn giao dịch. Vui lòng tải lại trang hoặc thử lại sau.",
   "token": "Token",
+  "tokenIssuer": "{{name}} Người phát hành",
   "tokens": "Các token",
   "smartContract": "Hợp đồng thông minh",
   "smartContracts": "Các hợp đồng thông minh",

--- a/public/locales/zh/network-page.json
+++ b/public/locales/zh/network-page.json
@@ -92,6 +92,7 @@
   "exchanges": "交易所",
   "exchangesLoadFailed": "错误：无法加载交易所。请刷新页面或稍后再试。",
   "token": "代币",
+  "tokenIssuer": "{{name}} 发行人",
   "tokens": "代币",
   "smartContract": "智能合约",
   "smartContracts": "智能合约",

--- a/src/hooks/useGetAddressName.ts
+++ b/src/hooks/useGetAddressName.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   useGetAddressLabelsQuery,
   useGetExchangesQuery,
@@ -21,6 +22,7 @@ export type GetAddressNameResult = {
  * Note: Fetches all assets once and filters in memory for efficiency
  */
 export function useGetAddressName(address: string): GetAddressNameResult | undefined {
+  const { t } = useTranslation('network-page')
   const { data: smartContracts } = useGetSmartContractsQuery()
   const { data: exchanges } = useGetExchangesQuery()
   const { data: addressLabels } = useGetAddressLabelsQuery()
@@ -56,10 +58,12 @@ export function useGetAddressName(address: string): GetAddressNameResult | undef
       )
       if (tokenIssuance) {
         // Try to find matching token data from static API to get website
-        const tokenData = tokens?.find((t) => t.name === tokenIssuance.data.name)
+        const tokenData = tokens?.find(
+          (tk) => tk.name === tokenIssuance.data.name && tk.issuer != null && tk.issuer === address
+        )
         return {
-          name: tokenIssuance.data.name,
-          i18nKey: 'token',
+          name: t('tokenIssuer', { name: tokenIssuance.data.name }),
+          i18nKey: 'tokenIssuer',
           website: tokenData?.website
         }
       }
@@ -75,5 +79,5 @@ export function useGetAddressName(address: string): GetAddressNameResult | undef
     }
 
     return undefined
-  }, [address, smartContracts, exchanges, addressLabels, tokens, allAssetsIssuances])
+  }, [address, smartContracts, exchanges, addressLabels, tokens, allAssetsIssuances, t])
 }

--- a/src/pages/network/address/AddressPage.tsx
+++ b/src/pages/network/address/AddressPage.tsx
@@ -150,7 +150,7 @@ function AddressPage() {
       {addressName && (
         <div className="flex items-center gap-4 pb-16">
           {/* Type Label (not for named addresses) */}
-          {addressName.i18nKey !== 'named-address' && (
+          {addressName.i18nKey !== 'named-address' && addressName.i18nKey !== 'tokenIssuer' && (
             <Badge color="primary" size="xs" variant="outlined">
               {t(addressName.i18nKey)}
             </Badge>

--- a/src/store/apis/qubic-static/qubic-static.types.ts
+++ b/src/store/apis/qubic-static/qubic-static.types.ts
@@ -39,6 +39,7 @@ export type GetAddressLabelsResponse = {
 
 export type Token = {
   name: string
+  issuer?: string
   website: string
 }
 


### PR DESCRIPTION
Display token issuers as "<name> Issuer" (e.g., "CFB Issuer") instead of two separate tags "Token" + "<name>". The change is centralized in useGetAddressName hook so all consumers (address page, transactions, events, rich list) show the unified label. Also match token website lookup by both name and issuer for correctness.