### PR TITLE
feat(frontend): use historical contract input decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@headlessui/react": "^2.1.2",
     "@qubic-lib/qubic-ts-library": "0.1.6",
-    "@qubic.ts/contracts": "^1.1.0",
+    "@qubic.ts/contracts": "^1.3.0",
     "@qubic.ts/core": "^1.1.0",
     "@react-spring/web": "^9.7.5",
     "@reduxjs/toolkit": "^2.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 0.1.6
         version: 0.1.6
       '@qubic.ts/contracts':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.3.0
+        version: 1.3.0
       '@qubic.ts/core':
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.5.3)
@@ -700,8 +700,8 @@ packages:
   '@qubic-lib/qubic-ts-library@0.1.6':
     resolution: {integrity: sha512-VbiJxFgmOpSKCgJkvPbUUFG/d8wcOYnh9pci1MXhINvUTD9i9twBKZv2SRc3v0fOTiasvaBeiz3HtUSy0oJfEA==}
 
-  '@qubic.ts/contracts@1.1.0':
-    resolution: {integrity: sha512-LLmYjjR2wyNp+6wlAXKZUG859FNRoOrnfLpw42b8w3m/m4oXVPjgMSUkT5H+NP8VtLTJABx02TOzqVbRfrozEQ==}
+  '@qubic.ts/contracts@1.3.0':
+    resolution: {integrity: sha512-LyW2athyV9X01QjANOOEnluY2+S5dL9F0hfd2yJ1WZWqekr97wHDIlPaiKFX2fDu1rDMe4fs8ffolvtW2Whd+A==}
 
   '@qubic.ts/core@1.1.0':
     resolution: {integrity: sha512-T/CS4eustTEdDYw0D+yZMr/APLFKKpzbliuz59cjMKJvW0sQvEABlvedCySRl1YvswcrwPqKC0nnMz8yKxLF/A==}
@@ -4600,7 +4600,7 @@ snapshots:
       bignumber.js: 9.1.2
       net: 1.0.2
 
-  '@qubic.ts/contracts@1.1.0':
+  '@qubic.ts/contracts@1.3.0':
     dependencies:
       zod: 4.3.6
 

--- a/src/pages/network/components/TxItem/TransactionDetails.tsx
+++ b/src/pages/network/components/TxItem/TransactionDetails.tsx
@@ -68,6 +68,7 @@ export default function TransactionDetails({
   const { isContractTransaction, shouldDecodeInput, decodedInput } = useDecodedContractInput({
     showExtendedDetails,
     destination,
+    tickNumber,
     inputType,
     inputData
   })

--- a/src/pages/network/components/TxItem/useDecodedContractInput.ts
+++ b/src/pages/network/components/TxItem/useDecodedContractInput.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useGetTickDataQuery } from '@app/store/apis/query-service'
 import {
   decodeContractInputData,
   type DecodedContractInput
@@ -9,6 +10,7 @@ import { isSmartContractTx } from '@app/utils/qubic-ts'
 type UseDecodedContractInputParams = Readonly<{
   showExtendedDetails: boolean
   destination: string
+  tickNumber: number
   inputType: number
   inputData: string | Uint8Array | number[] | null | undefined
 }>
@@ -37,14 +39,27 @@ export const useDecodedContractInput = (
     [params.showExtendedDetails, isContractTransaction, params.inputData, params.inputType]
   )
 
+  const { data: tickData } = useGetTickDataQuery(params.tickNumber, {
+    skip: !shouldDecodeInput
+  })
+
   const decodedInput = useMemo(() => {
     if (!shouldDecodeInput) return null
+    if (!tickData?.epoch) return null
+
     return decodeContractInputData({
+      epoch: tickData.epoch,
       inputType: params.inputType,
       inputData: params.inputData,
       destinationHint: params.destination
     })
-  }, [shouldDecodeInput, params.inputData, params.inputType, params.destination])
+  }, [
+    shouldDecodeInput,
+    tickData?.epoch,
+    params.inputData,
+    params.inputType,
+    params.destination
+  ])
 
   return {
     isContractTransaction,

--- a/src/pages/network/components/TxItem/useDecodedContractInput.ts
+++ b/src/pages/network/components/TxItem/useDecodedContractInput.ts
@@ -53,13 +53,7 @@ export const useDecodedContractInput = (
       inputData: params.inputData,
       destinationHint: params.destination
     })
-  }, [
-    shouldDecodeInput,
-    tickData?.epoch,
-    params.inputData,
-    params.inputType,
-    params.destination
-  ])
+  }, [shouldDecodeInput, tickData?.epoch, params.inputData, params.inputType, params.destination])
 
   return {
     isContractTransaction,

--- a/src/utils/contract-input-decoder.ts
+++ b/src/utils/contract-input-decoder.ts
@@ -1,19 +1,12 @@
 import {
-  decodeContractEntryInputData,
-  coreContractsRegistry,
-  type ContractEntryKind
+  coreVersionedContractsRegistry,
+  decodeHistoricalTransactionInput,
+  type ContractDefinition,
+  type ContractEntry,
+  type ContractEntryKind,
+  type ContractVersionDefinition
 } from '@qubic.ts/contracts'
 import { identityFromPublicKey } from '@qubic.ts/core'
-
-type RegistryEntryRef = Readonly<{
-  contractName: string
-  contractIndex: number
-  entryName: string
-  inputTypeName: string
-  kind: ContractEntryKind
-  inputType: number
-  inputSize?: number
-}>
 
 export type DecodedContractInput =
   | Readonly<{
@@ -25,44 +18,47 @@ export type DecodedContractInput =
       inputType: number
       value: unknown
       identityPaths: ReadonlySet<string>
+      decodeMode: 'typed' | 'named' | 'raw'
     }>
   | Readonly<{
       status: 'unsupported'
-      reason: 'missing-input-data' | 'invalid-input-data' | 'no-match' | 'decode-failed'
+      reason:
+        | 'missing-input-data'
+        | 'invalid-input-data'
+        | 'missing-epoch'
+        | 'no-match'
+        | 'decode-failed'
       message?: string
     }>
-
-const registryEntries: readonly RegistryEntryRef[] = coreContractsRegistry.contracts.flatMap(
-  (contract) =>
-    contract.entries.map((entry) => ({
-      contractName: contract.name,
-      contractIndex: contract.contractIndex,
-      entryName: entry.name,
-      inputTypeName: entry.inputTypeName,
-      kind: entry.kind,
-      inputType: entry.inputType,
-      inputSize: 'inputSize' in entry ? entry.inputSize : undefined
-    }))
-)
-
-const entriesByInputType = new Map<number, RegistryEntryRef[]>()
-registryEntries.forEach((entry) => {
-  const current = entriesByInputType.get(entry.inputType)
-  if (current) {
-    current.push(entry)
-  } else {
-    entriesByInputType.set(entry.inputType, [entry])
-  }
-})
-
-const registryContractNameByAddress = new Map<string, string>()
-coreContractsRegistry.contracts.forEach((contract) => {
-  registryContractNameByAddress.set(contract.address.trim().toUpperCase(), contract.name.trim())
-})
 
 const MAX_INPUT_DATA_LENGTH = 64 * 1024
 const HEX_32_BYTES = /^0x[0-9a-fA-F]{64}$/
 const DECIMAL_STRING = /^\d+$/
+const ROOT_PATH = ''
+
+type IoTypeLike = Readonly<{
+  kind: string
+  name: string
+  target?: string
+  fields?: readonly Readonly<{ name: string; type: string }>[]
+}>
+
+type ContractDecodeMetadata = Readonly<{
+  contract: ContractDefinition
+  entry: ContractEntry
+  fingerprint: string
+}>
+
+const versionByContractAndFingerprint = new Map<string, ContractVersionDefinition>()
+
+coreVersionedContractsRegistry.contracts.forEach((timeline) => {
+  timeline.versions.forEach((version) => {
+    versionByContractAndFingerprint.set(
+      `${timeline.contractIndex}:${version.fingerprint}`,
+      version
+    )
+  })
+})
 
 const bytesFromBase64 = (value: string): Uint8Array => {
   const decoded = atob(value)
@@ -72,9 +68,6 @@ const bytesFromBase64 = (value: string): Uint8Array => {
   }
   return bytes
 }
-
-const getErrorMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)
 
 const toBytes = (
   inputData: string | Uint8Array | number[] | null | undefined
@@ -105,13 +98,6 @@ const toBytes = (
   }
 }
 
-type IoTypeLike = Readonly<{
-  kind: string
-  name: string
-  target?: string
-  fields?: readonly Readonly<{ name: string; type: string }>[]
-}>
-
 const normalizeTypeExpression = (typeExpression: string): string =>
   typeExpression.replace(/\s+/g, '')
 
@@ -134,13 +120,13 @@ const isIdentityTypeExpression = (typeExpression: string): boolean => {
   return arraySpec ? isIdentityTypeExpression(arraySpec.elementType) : false
 }
 
-const ioTypeMapByContractName = new Map<string, ReadonlyMap<string, IoTypeLike>>()
+const ioTypeMapByFingerprint = new Map<string, ReadonlyMap<string, IoTypeLike>>()
 
-const getIoTypeMapForContract = (contractName: string): ReadonlyMap<string, IoTypeLike> | null => {
-  const contract = coreContractsRegistry.contracts.find((item) => item.name === contractName)
-  if (!contract) return null
-
-  const cached = ioTypeMapByContractName.get(contract.name)
+const getIoTypeMapForContract = (
+  contract: ContractDefinition,
+  fingerprint: string
+): ReadonlyMap<string, IoTypeLike> => {
+  const cached = ioTypeMapByFingerprint.get(fingerprint)
   if (cached) return cached
 
   const ioTypes = contract.ioTypes ?? []
@@ -148,16 +134,17 @@ const getIoTypeMapForContract = (contractName: string): ReadonlyMap<string, IoTy
   ioTypes.forEach((ioType) => {
     ioTypeMap.set(ioType.name, ioType)
   })
-  ioTypeMapByContractName.set(contract.name, ioTypeMap)
+  ioTypeMapByFingerprint.set(fingerprint, ioTypeMap)
   return ioTypeMap
 }
 
 const collectPathsByPredicate = (
-  candidate: RegistryEntryRef,
+  contract: ContractDefinition,
+  entry: ContractEntry,
+  fingerprint: string,
   isMatch: (normalizedTypeExpression: string) => boolean
 ): ReadonlySet<string> => {
-  const ioTypeMap = getIoTypeMapForContract(candidate.contractName)
-  if (!ioTypeMap) return new Set<string>()
+  const ioTypeMap = getIoTypeMapForContract(contract, fingerprint)
 
   const matchingPaths = new Set<string>()
   const visitedTypeNames = new Set<string>()
@@ -205,18 +192,22 @@ const collectPathsByPredicate = (
     visitByTypeName(ioType.name, path)
   }
 
-  visitByTypeName(candidate.inputTypeName, '')
+  visitByTypeName(entry.inputTypeName ?? `${entry.name}_input`, '')
   return matchingPaths
 }
 
-const collectIdentityPathsForInput = (candidate: RegistryEntryRef): ReadonlySet<string> =>
-  collectPathsByPredicate(candidate, isIdentityTypeExpression)
+const collectIdentityPathsForInput = (
+  contract: ContractDefinition,
+  entry: ContractEntry,
+  fingerprint: string
+): ReadonlySet<string> => collectPathsByPredicate(contract, entry, fingerprint, isIdentityTypeExpression)
 
-const collectUint64PathsForInput = (candidate: RegistryEntryRef): ReadonlySet<string> =>
-  collectPathsByPredicate(
-    candidate,
-    (normalizedTypeExpression) => normalizedTypeExpression === 'uint64'
-  )
+const collectUint64PathsForInput = (
+  contract: ContractDefinition,
+  entry: ContractEntry,
+  fingerprint: string
+): ReadonlySet<string> =>
+  collectPathsByPredicate(contract, entry, fingerprint, (normalizedTypeExpression) => normalizedTypeExpression === 'uint64')
 
 const isHumanReadableU64Path = (path: string): boolean => {
   const normalized = path.trim().toLowerCase()
@@ -226,9 +217,11 @@ const isHumanReadableU64Path = (path: string): boolean => {
 }
 
 const collectHumanReadableUint64PathsForInput = (
-  candidate: RegistryEntryRef
+  contract: ContractDefinition,
+  entry: ContractEntry,
+  fingerprint: string
 ): ReadonlySet<string> => {
-  const uint64Paths = collectUint64PathsForInput(candidate)
+  const uint64Paths = collectUint64PathsForInput(contract, entry, fingerprint)
   return new Set(Array.from(uint64Paths).filter((path) => isHumanReadableU64Path(path)))
 }
 
@@ -278,7 +271,7 @@ const decodeU64AsciiIfLikely = (value: unknown): string | null => {
 
 const normalizeDecodedValue = (
   value: unknown,
-  path = '',
+  path = ROOT_PATH,
   identityPaths?: ReadonlySet<string>,
   humanReadableUint64Paths?: ReadonlySet<string>
 ): unknown => {
@@ -320,123 +313,123 @@ const normalizeDecodedValue = (
   return value
 }
 
-const decodeCandidate = (candidate: RegistryEntryRef, bytes: Uint8Array) =>
-  decodeContractEntryInputData({
-    registry: coreContractsRegistry,
-    contractName: candidate.contractName,
-    entryName: candidate.entryName,
-    kind: candidate.kind,
-    bytes
-  })
+const getVersionLookupKey = (contractIndex: number, fingerprint: string): string =>
+  `${contractIndex}:${fingerprint}`
 
-const sortCandidatesForTxInput = (
-  candidates: readonly RegistryEntryRef[],
-  byteLength: number
-): RegistryEntryRef[] =>
-  [...candidates].sort((a, b) => {
-    const aKindRank = a.kind === 'procedure' ? 0 : 1
-    const bKindRank = b.kind === 'procedure' ? 0 : 1
-    if (aKindRank !== bKindRank) return aKindRank - bKindRank
+const resolveContractDecodeMetadata = (
+  contractIndex: number,
+  fingerprint: string,
+  entryKind: ContractEntryKind,
+  entryInputType: number,
+  entryName: string
+): ContractDecodeMetadata | null => {
+  const version = versionByContractAndFingerprint.get(getVersionLookupKey(contractIndex, fingerprint))
+  if (!version) return null
 
-    const aSizeGap =
-      a.inputSize === undefined ? Number.MAX_SAFE_INTEGER : Math.abs(a.inputSize - byteLength)
-    const bSizeGap =
-      b.inputSize === undefined ? Number.MAX_SAFE_INTEGER : Math.abs(b.inputSize - byteLength)
-    if (aSizeGap !== bSizeGap) return aSizeGap - bSizeGap
+  const entry = version.contract.entries.find(
+    (candidate) =>
+      candidate.kind === entryKind &&
+      candidate.inputType === entryInputType &&
+      candidate.name === entryName
+  )
+  if (!entry) return null
 
-    return a.entryName.localeCompare(b.entryName)
-  })
+  return {
+    contract: version.contract,
+    entry,
+    fingerprint: version.fingerprint
+  }
+}
+
+const createUnsupportedResult = (
+  reason: Extract<DecodedContractInput, { status: 'unsupported' }>['reason'],
+  message?: string
+): DecodedContractInput => ({
+  status: 'unsupported',
+  reason,
+  ...(message ? { message } : {})
+})
 
 export const decodeContractInputData = (params: {
   inputType: number
   inputData: string | Uint8Array | number[] | null | undefined
   destinationHint?: string | null
+  epoch?: number | null
 }): DecodedContractInput => {
   if (params.inputType <= 0) {
-    return {
-      status: 'unsupported',
-      reason: 'no-match',
-      message: 'Input type must be greater than zero for contract decoding.'
-    }
+    return createUnsupportedResult(
+      'no-match',
+      'Input type must be greater than zero for contract decoding.'
+    )
   }
 
   const { bytes, invalid } = toBytes(params.inputData)
   if (invalid) {
-    return { status: 'unsupported', reason: 'invalid-input-data' }
+    return createUnsupportedResult('invalid-input-data')
   }
   if (!bytes) {
-    return { status: 'unsupported', reason: 'missing-input-data' }
+    return createUnsupportedResult('missing-input-data')
+  }
+  if (!params.epoch || params.epoch <= 0) {
+    return createUnsupportedResult('missing-epoch')
   }
 
-  const candidates = entriesByInputType.get(params.inputType) ?? []
-  if (candidates.length === 0) {
-    return { status: 'unsupported', reason: 'no-match' }
-  }
-
-  const destinationContractName = params.destinationHint
-    ? registryContractNameByAddress.get(params.destinationHint.trim().toUpperCase())
-    : undefined
-
-  const preferredCandidates = destinationContractName
-    ? candidates.filter((candidate) => candidate.contractName === destinationContractName)
-    : []
-  const fallbackCandidates = destinationContractName
-    ? candidates.filter((candidate) => candidate.contractName !== destinationContractName)
-    : candidates
-  const orderedCandidates = [
-    ...sortCandidatesForTxInput(preferredCandidates, bytes.length),
-    ...sortCandidatesForTxInput(fallbackCandidates, bytes.length)
-  ]
-
-  let firstDecodeError: string | undefined
-  let decodedResult: DecodedContractInput | null = null
-
-  orderedCandidates.some((candidate) => {
-    try {
-      let decoded
-      try {
-        decoded = decodeCandidate(candidate, bytes)
-      } catch (error) {
-        if (candidate.inputSize === undefined || bytes.length >= candidate.inputSize) {
-          throw error
-        }
-
-        const paddedBytes = new Uint8Array(candidate.inputSize)
-        paddedBytes.set(bytes)
-        decoded = decodeCandidate(candidate, paddedBytes)
-      }
-
-      const identityPaths = collectIdentityPathsForInput(candidate)
-      decodedResult = {
-        status: 'decoded',
-        contractName: candidate.contractName,
-        contractIndex: candidate.contractIndex,
-        entryName: candidate.entryName,
-        kind: candidate.kind,
-        inputType: candidate.inputType,
-        value: normalizeDecodedValue(
-          decoded.value,
-          '',
-          identityPaths,
-          collectHumanReadableUint64PathsForInput(candidate)
-        ),
-        identityPaths
-      }
-
-      return true
-    } catch (error) {
-      if (!firstDecodeError) {
-        firstDecodeError = getErrorMessage(error)
-      }
-      return false
-    }
+  const decoded = decodeHistoricalTransactionInput({
+    registry: coreVersionedContractsRegistry,
+    destination: params.destinationHint ?? undefined,
+    inputType: params.inputType,
+    inputBytes: bytes,
+    epoch: params.epoch
   })
 
-  if (decodedResult) return decodedResult
+  if (!decoded.resolvedVersion || !decoded.entry) {
+    return createUnsupportedResult('no-match')
+  }
+
+  const metadata = resolveContractDecodeMetadata(
+    decoded.resolvedVersion.contractIndex,
+    decoded.resolvedVersion.fingerprint,
+    decoded.entry.kind,
+    decoded.entry.inputType,
+    decoded.entry.name
+  )
+  if (!metadata) {
+    return createUnsupportedResult(
+      'decode-failed',
+      'Resolved contract version metadata was not found in the bundled registry.'
+    )
+  }
+
+  const identityPaths = collectIdentityPathsForInput(
+    metadata.contract,
+    metadata.entry,
+    metadata.fingerprint
+  )
+  const humanReadableUint64Paths = collectHumanReadableUint64PathsForInput(
+    metadata.contract,
+    metadata.entry,
+    metadata.fingerprint
+  )
+
+  const normalizedValue =
+    decoded.decoded.mode === 'typed'
+      ? normalizeDecodedValue(decoded.decoded.value, ROOT_PATH, identityPaths, humanReadableUint64Paths)
+      : normalizeDecodedValue(
+          { rawBytes: decoded.decoded.rawBytes },
+          ROOT_PATH,
+          identityPaths,
+          humanReadableUint64Paths
+        )
 
   return {
-    status: 'unsupported',
-    reason: 'decode-failed',
-    message: firstDecodeError
+    status: 'decoded',
+    contractName: decoded.resolvedVersion.contractName,
+    contractIndex: decoded.resolvedVersion.contractIndex,
+    entryName: decoded.entry.name,
+    kind: decoded.entry.kind,
+    inputType: decoded.entry.inputType,
+    value: normalizedValue,
+    identityPaths,
+    decodeMode: decoded.decoded.mode
   }
 }

--- a/src/utils/contract-input-decoder.ts
+++ b/src/utils/contract-input-decoder.ts
@@ -53,10 +53,7 @@ const versionByContractAndFingerprint = new Map<string, ContractVersionDefinitio
 
 coreVersionedContractsRegistry.contracts.forEach((timeline) => {
   timeline.versions.forEach((version) => {
-    versionByContractAndFingerprint.set(
-      `${timeline.contractIndex}:${version.fingerprint}`,
-      version
-    )
+    versionByContractAndFingerprint.set(`${timeline.contractIndex}:${version.fingerprint}`, version)
   })
 })
 
@@ -200,14 +197,20 @@ const collectIdentityPathsForInput = (
   contract: ContractDefinition,
   entry: ContractEntry,
   fingerprint: string
-): ReadonlySet<string> => collectPathsByPredicate(contract, entry, fingerprint, isIdentityTypeExpression)
+): ReadonlySet<string> =>
+  collectPathsByPredicate(contract, entry, fingerprint, isIdentityTypeExpression)
 
 const collectUint64PathsForInput = (
   contract: ContractDefinition,
   entry: ContractEntry,
   fingerprint: string
 ): ReadonlySet<string> =>
-  collectPathsByPredicate(contract, entry, fingerprint, (normalizedTypeExpression) => normalizedTypeExpression === 'uint64')
+  collectPathsByPredicate(
+    contract,
+    entry,
+    fingerprint,
+    (normalizedTypeExpression) => normalizedTypeExpression === 'uint64'
+  )
 
 const isHumanReadableU64Path = (path: string): boolean => {
   const normalized = path.trim().toLowerCase()
@@ -323,7 +326,9 @@ const resolveContractDecodeMetadata = (
   entryInputType: number,
   entryName: string
 ): ContractDecodeMetadata | null => {
-  const version = versionByContractAndFingerprint.get(getVersionLookupKey(contractIndex, fingerprint))
+  const version = versionByContractAndFingerprint.get(
+    getVersionLookupKey(contractIndex, fingerprint)
+  )
   if (!version) return null
 
   const entry = version.contract.entries.find(
@@ -413,7 +418,12 @@ export const decodeContractInputData = (params: {
 
   const normalizedValue =
     decoded.decoded.mode === 'typed'
-      ? normalizeDecodedValue(decoded.decoded.value, ROOT_PATH, identityPaths, humanReadableUint64Paths)
+      ? normalizeDecodedValue(
+          decoded.decoded.value,
+          ROOT_PATH,
+          identityPaths,
+          humanReadableUint64Paths
+        )
       : normalizeDecodedValue(
           { rawBytes: decoded.decoded.rawBytes },
           ROOT_PATH,


### PR DESCRIPTION
## Summary

This updates the explorer transaction details flow to use epoch-aware historical contract input decoding.

## What changed

- switched contract input decoding from the current-only contracts registry to the versioned historical registry
- wired `tickNumber -> epoch` resolution into `useDecodedContractInput`
- passed `tickNumber` from `TransactionDetails` into the decode hook
- updated the frontend dependency to `@qubic.ts/contracts@^1.3.0`
- included the corresponding `pnpm-lock.yaml` refresh

## Why

The previous frontend integration decoded smart-contract inputs against the current registry only.
That can misdecode or fail for transactions from older epochs when contract layouts changed.

With this change, the explorer resolves the transaction epoch first and then decodes against the contract version active for that epoch.

## Validation

Code changes are scoped to the contract input decoding path and transaction details wiring.
