### PR TITLE
fix(frontend): bump contracts to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@headlessui/react": "^2.1.2",
     "@qubic-lib/qubic-ts-library": "0.1.6",
-    "@qubic.ts/contracts": "^1.3.0",
+    "@qubic.ts/contracts": "^1.3.1",
     "@qubic.ts/core": "^1.1.0",
     "@react-spring/web": "^9.7.5",
     "@reduxjs/toolkit": "^2.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 0.1.6
         version: 0.1.6
       '@qubic.ts/contracts':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@qubic.ts/core':
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.5.3)
@@ -700,8 +700,8 @@ packages:
   '@qubic-lib/qubic-ts-library@0.1.6':
     resolution: {integrity: sha512-VbiJxFgmOpSKCgJkvPbUUFG/d8wcOYnh9pci1MXhINvUTD9i9twBKZv2SRc3v0fOTiasvaBeiz3HtUSy0oJfEA==}
 
-  '@qubic.ts/contracts@1.3.0':
-    resolution: {integrity: sha512-LyW2athyV9X01QjANOOEnluY2+S5dL9F0hfd2yJ1WZWqekr97wHDIlPaiKFX2fDu1rDMe4fs8ffolvtW2Whd+A==}
+  '@qubic.ts/contracts@1.3.1':
+    resolution: {integrity: sha512-2rQ3W5oTDVNI8L+t4zQrvaTjcb+ql63eS/Ksd+Il/35NgXsl3MiF+43agF77bGdIRa5IpA0IITS/PCV3+8+m+A==}
 
   '@qubic.ts/core@1.1.0':
     resolution: {integrity: sha512-T/CS4eustTEdDYw0D+yZMr/APLFKKpzbliuz59cjMKJvW0sQvEABlvedCySRl1YvswcrwPqKC0nnMz8yKxLF/A==}
@@ -4600,7 +4600,7 @@ snapshots:
       bignumber.js: 9.1.2
       net: 1.0.2
 
-  '@qubic.ts/contracts@1.3.0':
+  '@qubic.ts/contracts@1.3.1':
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
## Summary

Bump `@qubic.ts/contracts` from `1.3.0` to `1.3.1`.

## Why

`@qubic.ts/contracts@1.3.0` exposed Node-only generator code through the root package entry. That breaks browser bundling in frontend consumers.

`1.3.1` fixes the package exports so browser apps can continue importing from the root contracts entry safely.

## Changes

- update `@qubic.ts/contracts` to `^1.3.1`
- refresh `pnpm-lock.yaml`

## Validation

- `pnpm lint`
- `pnpm build`
