### PR TITLE
fix(frontend): update contracts decoder to 1.6.2 and harden input decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@headlessui/react": "^2.1.2",
     "@qubic-lib/qubic-ts-library": "0.1.6",
-    "@qubic.ts/contracts": "^1.6.1",
-    "@qubic.ts/core": "^1.6.1",
+    "@qubic.ts/contracts": "^1.6.2",
+    "@qubic.ts/core": "^1.6.2",
     "@react-spring/web": "^9.7.5",
     "@reduxjs/toolkit": "^2.2.6",
     "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@headlessui/react": "^2.1.2",
     "@qubic-lib/qubic-ts-library": "0.1.6",
-    "@qubic.ts/contracts": "^1.3.1",
-    "@qubic.ts/core": "^1.1.0",
+    "@qubic.ts/contracts": "^1.6.1",
+    "@qubic.ts/core": "^1.6.1",
     "@react-spring/web": "^9.7.5",
     "@reduxjs/toolkit": "^2.2.6",
     "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 0.1.6
         version: 0.1.6
       '@qubic.ts/contracts':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.6.1
+        version: 1.6.2
       '@qubic.ts/core':
-        specifier: ^1.1.0
-        version: 1.1.0(typescript@5.5.3)
+        specifier: ^1.6.1
+        version: 1.6.2(typescript@5.5.3)
       '@react-spring/web':
         specifier: ^9.7.5
         version: 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -700,11 +700,11 @@ packages:
   '@qubic-lib/qubic-ts-library@0.1.6':
     resolution: {integrity: sha512-VbiJxFgmOpSKCgJkvPbUUFG/d8wcOYnh9pci1MXhINvUTD9i9twBKZv2SRc3v0fOTiasvaBeiz3HtUSy0oJfEA==}
 
-  '@qubic.ts/contracts@1.3.1':
-    resolution: {integrity: sha512-2rQ3W5oTDVNI8L+t4zQrvaTjcb+ql63eS/Ksd+Il/35NgXsl3MiF+43agF77bGdIRa5IpA0IITS/PCV3+8+m+A==}
+  '@qubic.ts/contracts@1.6.2':
+    resolution: {integrity: sha512-xrZK9Dw0x/vLfiLIRmfPpimuKaNmZOLOvnaseKuNHKij7Bgbg/ZOFZDmaowoxU90rA57uU0mg935zhS5lGdMEQ==}
 
-  '@qubic.ts/core@1.1.0':
-    resolution: {integrity: sha512-T/CS4eustTEdDYw0D+yZMr/APLFKKpzbliuz59cjMKJvW0sQvEABlvedCySRl1YvswcrwPqKC0nnMz8yKxLF/A==}
+  '@qubic.ts/core@1.6.2':
+    resolution: {integrity: sha512-5w5jBe+4pWXCHii+bxFZFYpwLHLitf6rwI4tdkvstO+SbIxDSyyzb+vxlYz1hJc3xCXida6T4IJDFFN67+rnmg==}
 
   '@react-aria/focus@3.18.1':
     resolution: {integrity: sha512-N0Cy61WCIv+57mbqC7hiZAsB+3rF5n4JKabxUmg/2RTJL6lq7hJ5N4gx75ymKxkN8GnVDwt4pKZah48Wopa5jw==}
@@ -4600,11 +4600,11 @@ snapshots:
       bignumber.js: 9.1.2
       net: 1.0.2
 
-  '@qubic.ts/contracts@1.3.1':
+  '@qubic.ts/contracts@1.6.2':
     dependencies:
       zod: 4.3.6
 
-  '@qubic.ts/core@1.1.0(typescript@5.5.3)':
+  '@qubic.ts/core@1.6.2(typescript@5.5.3)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@qubic-labs/schnorrq': 1.0.2(typescript@5.5.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
         specifier: 0.1.6
         version: 0.1.6
       '@qubic.ts/contracts':
-        specifier: ^1.6.1
+        specifier: ^1.6.2
         version: 1.6.2
       '@qubic.ts/core':
-        specifier: ^1.6.1
+        specifier: ^1.6.2
         version: 1.6.2(typescript@5.5.3)
       '@react-spring/web':
         specifier: ^9.7.5

--- a/src/pages/network/components/TxItem/DecodedInputTable.tsx
+++ b/src/pages/network/components/TxItem/DecodedInputTable.tsx
@@ -12,6 +12,11 @@ type FlatRow = Readonly<{ key: string; value: string }>
 const MAX_FLATTEN_DEPTH = 20
 const MONOSPACE_VALUE_MIN_LENGTH = 24
 
+const isZeroByteArray = (value: readonly unknown[]): boolean =>
+  value.length > 0 &&
+  value.every((item) => Number.isInteger(item) && Number(item) >= 0 && Number(item) <= 255) &&
+  value.every((item) => Number(item) === 0)
+
 const toDisplayValue = (value: unknown): string => {
   if (value === null || value === undefined) return '--'
   if (typeof value === 'bigint') return value.toString()
@@ -48,6 +53,9 @@ const flattenDecodedValue = (
       return [{ key: path || 'value', value: '[Circular]' }]
     }
     seen.add(value)
+    if (isZeroByteArray(value)) {
+      return [{ key: path || 'value', value: `[all zeros: ${value.length} bytes]` }]
+    }
     return value.flatMap((item, index) =>
       flattenDecodedValue(item, path ? `${path}[${index}]` : `[${index}]`, depth + 1, seen)
     )

--- a/src/pages/network/components/TxItem/TransactionDetails.tsx
+++ b/src/pages/network/components/TxItem/TransactionDetails.tsx
@@ -67,6 +67,7 @@ export default function TransactionDetails({
   )
   const { isContractTransaction, shouldDecodeInput, decodedInput } = useDecodedContractInput({
     showExtendedDetails,
+    tickNumber,
     destination,
     tickNumber,
     inputType,

--- a/src/pages/network/components/TxItem/useDecodedContractInput.ts
+++ b/src/pages/network/components/TxItem/useDecodedContractInput.ts
@@ -9,8 +9,8 @@ import { isSmartContractTx } from '@app/utils/qubic-ts'
 
 type UseDecodedContractInputParams = Readonly<{
   showExtendedDetails: boolean
-  destination: string
   tickNumber: number
+  destination: string
   inputType: number
   inputData: string | Uint8Array | number[] | null | undefined
 }>

--- a/src/utils/contract-input-decoder.ts
+++ b/src/utils/contract-input-decoder.ts
@@ -219,6 +219,31 @@ const isHumanReadableU64Path = (path: string): boolean => {
   return /name|symbol|ticker|label|code|unit/.test(lastSegment)
 }
 
+const isHumanReadableByteArrayPath = (path: string): boolean => {
+  const normalized = path.trim().toLowerCase()
+  if (!normalized) return false
+  const lastSegment = normalized.split('.').at(-1) ?? normalized
+  return /url|name|symbol|ticker|label|code|unit|title|description|memo|text/.test(lastSegment)
+}
+
+const decodeAsciiByteArray = (value: readonly number[]): string | null => {
+  if (value.length === 0) return null
+  if (!value.every((item) => Number.isInteger(item) && item >= 0 && item <= 255)) return null
+
+  const bytes = Uint8Array.from(value)
+  const zeroIndex = bytes.indexOf(0)
+  const endIndex = zeroIndex === -1 ? bytes.length : zeroIndex
+  if (endIndex === 0) return ''
+
+  if (zeroIndex !== -1 && !bytes.subarray(zeroIndex).every((byte) => byte === 0)) return null
+
+  const printable = bytes.subarray(0, endIndex)
+  const allPrintable = printable.every((byte) => byte >= 32 && byte <= 126)
+  if (!allPrintable) return null
+
+  return String.fromCharCode(...printable)
+}
+
 const collectHumanReadableUint64PathsForInput = (
   contract: ContractDefinition,
   entry: ContractEntry,
@@ -300,6 +325,10 @@ const normalizeDecodedValue = (
       .join('')}`
   }
   if (Array.isArray(value)) {
+    if (isHumanReadableByteArrayPath(path)) {
+      const decodedText = decodeAsciiByteArray(value as readonly number[])
+      if (decodedText !== null) return decodedText
+    }
     return value.map((item) =>
       normalizeDecodedValue(item, path, identityPaths, humanReadableUint64Paths)
     )

--- a/src/utils/contract-input-decoder.ts
+++ b/src/utils/contract-input-decoder.ts
@@ -408,13 +408,21 @@ export const decodeContractInputData = (params: {
     return createUnsupportedResult('missing-epoch')
   }
 
-  const decoded = decodeHistoricalTransactionInput({
-    registry: coreVersionedContractsRegistry,
-    destination: params.destinationHint ?? undefined,
-    inputType: params.inputType,
-    inputBytes: bytes,
-    epoch: params.epoch
-  })
+  let decoded: ReturnType<typeof decodeHistoricalTransactionInput>
+  try {
+    decoded = decodeHistoricalTransactionInput({
+      registry: coreVersionedContractsRegistry,
+      destination: params.destinationHint ?? undefined,
+      inputType: params.inputType,
+      inputBytes: bytes,
+      epoch: params.epoch
+    })
+  } catch (error) {
+    return createUnsupportedResult(
+      'decode-failed',
+      error instanceof Error ? error.message : String(error)
+    )
+  }
 
   if (!decoded.resolvedVersion || !decoded.entry) {
     return createUnsupportedResult('no-match')

--- a/src/utils/contract-input-decoder.ts
+++ b/src/utils/contract-input-decoder.ts
@@ -5,7 +5,7 @@ import {
   type ContractEntry,
   type ContractEntryKind,
   type ContractVersionDefinition
-} from '@qubic.ts/contracts'
+} from '@qubic.ts/contracts/browser'
 import { identityFromPublicKey } from '@qubic.ts/core'
 
 export type DecodedContractInput =


### PR DESCRIPTION
## Summary
- Upgrade explorer dependencies to `@qubic.ts/contracts@^1.6.2` and `@qubic.ts/core@^1.6.2`
- Keep browser-safe decode path on `@qubic.ts/contracts/browser`
- Preserve graceful UI handling for decode exceptions (`decode-failed` with message instead of hard crash)
- Keep decoded input readability improvements for byte-array fields and zero-tail arrays

## Why
This updates explorer to the contracts runtime that fixes historical decode issues reported in production, including symbolic array-size resolution in `BuyTicket` inputs.

## Validation
- `pnpm lint`
- `pnpm build`
- Live RPC decode checks for reported transactions:
  - `dpqcfoaidhnwladhpraxjsmjktcffrgstrpgguyxtebnxfedovnjiighfrdh` -> `QEARN.unlock` typed decode
  - `irpqntgkoifnwgnufwmibrwoyukhbktykbstmhgstbuuzbrzpzexizsazatb` -> `GQMPROP.SetProposal` typed decode
  - `xhiifhmkdjigzakrgxnveiahjtkchvqrwzrlpnnbpeqjwwdzddftkfgarwlk` -> `QVAULT.TransferShareManagementRights` typed decode
  - `jvprmtyzxbkkabxqiihambfwrhjhmheaiocnkgxlhbcfeiorcuamrmiavipn` -> `PULSE.BuyTicket` typed decode (`digits` resolved)
  - `ibhnuywkniaorakdhbxrqqigjnsexywbjicflnbliauyvyxcuxupnjrafhgl` -> `QTF.BuyTicket` typed decode (`randomValues` resolved)
