### PR TITLE
feat: add issued-by tooltip and label for non-system-issued assets

### DIFF
--- a/public/locales/ar/network-page.json
+++ b/public/locales/ar/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "توسيع الكل",
   "collapseAll": "طي الكل",
   "managedBy": "يُدار بواسطة {{contract}}",
+  "issuedBy": "صادر من {{address}}",
+  "issuedByLabel": "صادر من",
   "unknownContract": "عقد غير معروف",
   "resetFilters": "إعادة تعيين الفلاتر",
   "startTick": "بداية التيك",

--- a/public/locales/de/network-page.json
+++ b/public/locales/de/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Alle erweitern",
   "collapseAll": "Alle einklappen",
   "managedBy": "Verwaltet von {{contract}}",
+  "issuedBy": "Ausgegeben von {{address}}",
+  "issuedByLabel": "Ausgegeben von",
   "unknownContract": "Unbekannter Vertrag",
   "resetFilters": "Filter zurücksetzen",
   "startTick": "Start-Tick",

--- a/public/locales/en/network-page.json
+++ b/public/locales/en/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Expand All",
   "collapseAll": "Collapse All",
   "managedBy": "Managed by {{contract}}",
+  "issuedBy": "Issued by {{address}}",
+  "issuedByLabel": "Issued by",
   "unknownContract": "Unknown Contract",
   "resetFilters": "Reset Filters",
   "startTick": "Start Tick",

--- a/public/locales/es/network-page.json
+++ b/public/locales/es/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Expandir todo",
   "collapseAll": "Contraer todo",
   "managedBy": "Gestionado por {{contract}}",
+  "issuedBy": "Emitido por {{address}}",
+  "issuedByLabel": "Emitido por",
   "unknownContract": "Contrato desconocido",
   "resetFilters": "Restablecer filtros",
   "startTick": "Tick inicial",

--- a/public/locales/fr/network-page.json
+++ b/public/locales/fr/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Tout développer",
   "collapseAll": "Tout réduire",
   "managedBy": "Géré par {{contract}}",
+  "issuedBy": "Émis par {{address}}",
+  "issuedByLabel": "Émis par",
   "unknownContract": "Contrat inconnu",
   "resetFilters": "Réinitialiser les filtres",
   "startTick": "Tick de début",

--- a/public/locales/ja/network-page.json
+++ b/public/locales/ja/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "すべて展開",
   "collapseAll": "すべて折りたたむ",
   "managedBy": "{{contract}}によって管理",
+  "issuedBy": "{{address}} が発行",
+  "issuedByLabel": "発行者",
   "unknownContract": "不明なコントラクト",
   "resetFilters": "フィルターをリセット",
   "startTick": "開始ティック",

--- a/public/locales/nl/network-page.json
+++ b/public/locales/nl/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Alles uitvouwen",
   "collapseAll": "Alles invouwen",
   "managedBy": "Beheerd door {{contract}}",
+  "issuedBy": "Uitgegeven door {{address}}",
+  "issuedByLabel": "Uitgegeven door",
   "unknownContract": "Onbekend contract",
   "resetFilters": "Filters resetten",
   "startTick": "Start tick",

--- a/public/locales/pt/network-page.json
+++ b/public/locales/pt/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Expandir tudo",
   "collapseAll": "Recolher tudo",
   "managedBy": "Gerenciado por {{contract}}",
+  "issuedBy": "Emitido por {{address}}",
+  "issuedByLabel": "Emitido por",
   "unknownContract": "Contrato desconhecido",
   "resetFilters": "Redefinir filtros",
   "startTick": "Tick inicial",

--- a/public/locales/ru/network-page.json
+++ b/public/locales/ru/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Развернуть все",
   "collapseAll": "Свернуть все",
   "managedBy": "Управляется {{contract}}",
+  "issuedBy": "Выпущено {{address}}",
+  "issuedByLabel": "Выпущено",
   "unknownContract": "Неизвестный контракт",
   "resetFilters": "Сбросить фильтры",
   "startTick": "Начальный тик",

--- a/public/locales/tr/network-page.json
+++ b/public/locales/tr/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Tümünü genişlet",
   "collapseAll": "Tümünü daralt",
   "managedBy": "{{contract}} tarafından yönetiliyor",
+  "issuedBy": "{{address}} tarafından yayınlandı",
+  "issuedByLabel": "Yayınlayan",
   "unknownContract": "Bilinmeyen sözleşme",
   "resetFilters": "Filtreleri sıfırla",
   "startTick": "Başlangıç tick",

--- a/public/locales/vi/network-page.json
+++ b/public/locales/vi/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "Mở rộng tất cả",
   "collapseAll": "Thu gọn tất cả",
   "managedBy": "Được quản lý bởi {{contract}}",
+  "issuedBy": "Phát hành bởi {{address}}",
+  "issuedByLabel": "Phát hành bởi",
   "unknownContract": "Hợp đồng không xác định",
   "resetFilters": "Đặt lại bộ lọc",
   "startTick": "Tick bắt đầu",

--- a/public/locales/zh/network-page.json
+++ b/public/locales/zh/network-page.json
@@ -132,6 +132,8 @@
   "expandAll": "全部展開",
   "collapseAll": "全部摺疊",
   "managedBy": "由{{contract}}管理",
+  "issuedBy": "由 {{address}} 发行",
+  "issuedByLabel": "发行者",
   "unknownContract": "未知合约",
   "resetFilters": "重置筛选",
   "startTick": "起始Tick",

--- a/src/pages/network/address/components/OwnedAssets.tsx
+++ b/src/pages/network/address/components/OwnedAssets.tsx
@@ -2,6 +2,7 @@ import { animated, useSpring, useTransition } from '@react-spring/web'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { Tooltip } from '@app/components/ui'
 import { ChevronToggleButton } from '@app/components/ui/buttons'
 import { useGetAddressOwnedAssetsQuery } from '@app/store/apis/rpc-live'
 import { useGetSmartContractsQuery } from '@app/store/apis/qubic-static'
@@ -196,12 +197,17 @@ export default function OwnedAssets({ addressId }: Props) {
                 {isAssetsIssuerAddress(asset.issuerIdentity) ? (
                   <p className="font-space text-base text-gray-50">{asset.assetName}</p>
                 ) : (
-                  <AddressLink
-                    label={asset.assetName}
-                    value={asset.issuerIdentity}
-                    className="text-base"
-                    showContractIcon={false}
-                  />
+                  <Tooltip
+                    tooltipId={`asset-issuer-${asset.assetName}-${asset.issuerIdentity}`}
+                    content={t('issuedBy', { address: asset.issuerIdentity })}
+                  >
+                    <AddressLink
+                      label={asset.assetName}
+                      value={asset.issuerIdentity}
+                      className="text-base"
+                      showContractIcon={false}
+                    />
+                  </Tooltip>
                 )}
               </animated.li>
             ))}
@@ -240,12 +246,17 @@ export default function OwnedAssets({ addressId }: Props) {
                       {isAssetsIssuerAddress(asset.issuerIdentity) ? (
                         <p className="font-space text-base text-gray-50">{asset.assetName}</p>
                       ) : (
-                        <AddressLink
-                          label={asset.assetName}
-                          value={asset.issuerIdentity}
-                          className="text-base"
-                          showContractIcon={false}
-                        />
+                        <Tooltip
+                          tooltipId={`asset-issuer-expanded-${asset.assetName}-${asset.issuerIdentity}`}
+                          content={t('issuedBy', { address: asset.issuerIdentity })}
+                        >
+                          <AddressLink
+                            label={asset.assetName}
+                            value={asset.issuerIdentity}
+                            className="text-base"
+                            showContractIcon={false}
+                          />
+                        </Tooltip>
                       )}
                     </li>
                   ))}

--- a/src/pages/network/assets/rich-list/AssetsRichListPage.tsx
+++ b/src/pages/network/assets/rich-list/AssetsRichListPage.tsx
@@ -10,7 +10,8 @@ import type { Option } from '@app/components/ui/Select'
 import { useTailwindBreakpoint } from '@app/hooks'
 import { useGetAssetsIssuancesQuery } from '@app/store/apis/rpc-live'
 import { useGetAssetsRichListQuery } from '@app/store/apis/rpc-stats'
-import { HomeLink } from '../../components'
+import { isAssetsIssuerAddress } from '@app/utils/qubic-ts'
+import { AddressLink, HomeLink } from '../../components'
 import {
   AssetRichListEmptyRow,
   AssetRichListErrorRow,
@@ -179,6 +180,18 @@ function AssetsRichListPage() {
             options={pageSizeOptions}
           />
         </div>
+
+        {assetParam && issuerParam && isValidAsset && (
+          <div>
+            <p className="font-space text-base font-500 text-white">{assetParam}</p>
+            {!isAssetsIssuerAddress(issuerParam) && (
+              <div className="flex items-center gap-4 text-xs text-gray-50">
+                <span>{t('issuedByLabel')}</span>
+                <AddressLink value={issuerParam} ellipsis showTooltip className="text-xs" />
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="w-full rounded-12 border-1 border-primary-60 bg-primary-70">
           <div className="overflow-x-scroll">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,9 @@ const defaultConfig: UserConfig = {
       '@app': '/src'
     }
   },
+  optimizeDeps: {
+    exclude: ['@qubic.ts/contracts/generator']
+  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- Add "Issued by" tooltip on address page asset balances for non-system-issued assets
- Add asset name + clickable issuer link on assets rich list page
- Fix Vite `optimizeDeps` for `@qubic.ts/contracts/generator`