### PR TITLE
fix: hide shareholders button before shares auction epoch

### DIFF
--- a/src/pages/network/address/AddressPage.tsx
+++ b/src/pages/network/address/AddressPage.tsx
@@ -83,6 +83,12 @@ function AddressPage() {
 
   const isSmartContract = !!smartContractDetails
 
+  const showShareholders = useMemo(() => {
+    const epoch = latestStats.data?.epoch
+    const auctionEpoch = smartContractDetails?.sharesAuctionEpoch
+    return epoch !== undefined && auctionEpoch !== undefined && epoch > auctionEpoch
+  }, [latestStats.data?.epoch, smartContractDetails?.sharesAuctionEpoch])
+
   const [searchParams, setSearchParams] = useSearchParams()
   const tabParam = searchParams.get('tab')
 
@@ -252,6 +258,7 @@ function AddressPage() {
                 githubUrl={smartContractDetails.githubUrl}
                 proposalUrl={smartContractDetails.proposalUrl}
                 contractIndex={smartContractDetails.contractIndex}
+                showShareholders={showShareholders}
               />
             </Tabs.Panel>
           )}

--- a/src/pages/network/address/components/ContractActions.tsx
+++ b/src/pages/network/address/components/ContractActions.tsx
@@ -11,24 +11,33 @@ type Props = {
   code: string
   githubUrl: string
   proposalUrl?: string
+  showShareholders?: boolean
 }
 
-export default function ContractActions({ asset, code, githubUrl, proposalUrl }: Props) {
+export default function ContractActions({
+  asset,
+  code,
+  githubUrl,
+  proposalUrl,
+  showShareholders
+}: Props) {
   const { t } = useTranslation('network-page')
   return (
     <div className="flex gap-6 self-end">
-      <Tooltip content={t('checkContractShareholders')} tooltipId="check-shareholders">
-        <Button
-          className="h-[30px] w-fit"
-          size="xs"
-          variant="outlined"
-          color="secondary"
-          as={Link}
-          to={Routes.NETWORK.ASSETS.RICH_LIST(ASSETS_ISSUER_ADDRESS, asset)}
-        >
-          {t('shareholders')}
-        </Button>
-      </Tooltip>
+      {showShareholders && (
+        <Tooltip content={t('checkContractShareholders')} tooltipId="check-shareholders">
+          <Button
+            className="h-[30px] w-fit"
+            size="xs"
+            variant="outlined"
+            color="secondary"
+            as={Link}
+            to={Routes.NETWORK.ASSETS.RICH_LIST(ASSETS_ISSUER_ADDRESS, asset)}
+          >
+            {t('shareholders')}
+          </Button>
+        </Tooltip>
+      )}
       <a
         href={githubUrl}
         aria-label="Open GitHub code file"

--- a/src/pages/network/address/components/ContractOverview.tsx
+++ b/src/pages/network/address/components/ContractOverview.tsx
@@ -16,9 +16,16 @@ type Props = {
   githubUrl: string
   proposalUrl?: string
   contractIndex?: number
+  showShareholders?: boolean
 }
 
-export default function ContractOverview({ asset, githubUrl, proposalUrl, contractIndex }: Props) {
+export default function ContractOverview({
+  asset,
+  githubUrl,
+  proposalUrl,
+  contractIndex,
+  showShareholders
+}: Props) {
   const { t } = useTranslation('network-page')
   const [code, setCode] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
@@ -101,6 +108,7 @@ export default function ContractOverview({ asset, githubUrl, proposalUrl, contra
             code={code}
             githubUrl={githubUrl}
             proposalUrl={proposalUrl}
+            showShareholders={showShareholders}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Hide the Shareholders button on the Contract tab when the current epoch is not past the smart contract's `sharesAuctionEpoch`, since shares have not been generated yet
- Compute visibility in `AddressPage` and pass a single boolean prop down through `ContractOverview` to `ContractActions`