### PR TITLE
feat: display rawPayload field and copy buttons on event detail page

### DIFF
--- a/public/locales/ar/network-page.json
+++ b/public/locales/ar/network-page.json
@@ -185,6 +185,7 @@
   "rank": "الترتيب",
   "remaining": "المتبقي",
   "remainingAmount": "المبلغ المتبقي",
+  "rawPayload": "البيانات الخام",
   "removeAddress": "إزالة العنوان",
   "replyDigest": "ملخص الرد",
   "resetFilters": "إعادة تعيين الفلاتر",

--- a/public/locales/de/network-page.json
+++ b/public/locales/de/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rang",
   "remaining": "Verbleibend",
   "remainingAmount": "Verbleibender Betrag",
+  "rawPayload": "Rohdaten",
   "removeAddress": "Adresse entfernen",
   "replyDigest": "Antwort-Digest",
   "resetFilters": "Filter zurücksetzen",

--- a/public/locales/en/network-page.json
+++ b/public/locales/en/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rank",
   "remaining": "Remaining",
   "remainingAmount": "Remaining Amount",
+  "rawPayload": "Raw Payload",
   "removeAddress": "Remove address",
   "replyDigest": "Reply Digest",
   "resetFilters": "Reset Filters",

--- a/public/locales/es/network-page.json
+++ b/public/locales/es/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rango",
   "remaining": "Restante",
   "remainingAmount": "Monto Restante",
+  "rawPayload": "Datos sin procesar",
   "removeAddress": "Eliminar dirección",
   "replyDigest": "Resumen de respuesta",
   "resetFilters": "Restablecer filtros",

--- a/public/locales/fr/network-page.json
+++ b/public/locales/fr/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rang",
   "remaining": "Restant",
   "remainingAmount": "Montant restant",
+  "rawPayload": "Données brutes",
   "removeAddress": "Supprimer l'adresse",
   "replyDigest": "Résumé de réponse",
   "resetFilters": "Réinitialiser les filtres",

--- a/public/locales/ja/network-page.json
+++ b/public/locales/ja/network-page.json
@@ -185,6 +185,7 @@
   "rank": "ランク",
   "remaining": "残額",
   "remainingAmount": "残額",
+  "rawPayload": "生データ",
   "removeAddress": "アドレスを削除",
   "replyDigest": "回答ダイジェスト",
   "resetFilters": "フィルターをリセット",

--- a/public/locales/nl/network-page.json
+++ b/public/locales/nl/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rang",
   "remaining": "Resterend",
   "remainingAmount": "Resterend Bedrag",
+  "rawPayload": "Ruwe gegevens",
   "removeAddress": "Adres verwijderen",
   "replyDigest": "Antwoord-digest",
   "resetFilters": "Filters resetten",

--- a/public/locales/pt/network-page.json
+++ b/public/locales/pt/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Classificação",
   "remaining": "Restante",
   "remainingAmount": "Valor Restante",
+  "rawPayload": "Dados brutos",
   "removeAddress": "Remover endereço",
   "replyDigest": "Resumo da resposta",
   "resetFilters": "Redefinir filtros",

--- a/public/locales/ru/network-page.json
+++ b/public/locales/ru/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Ранг",
   "remaining": "Остаток",
   "remainingAmount": "Оставшаяся сумма",
+  "rawPayload": "Необработанные данные",
   "removeAddress": "Удалить адрес",
   "replyDigest": "Дайджест ответа",
   "resetFilters": "Сбросить фильтры",

--- a/public/locales/tr/network-page.json
+++ b/public/locales/tr/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Rütbe",
   "remaining": "Kalan",
   "remainingAmount": "Kalan Tutar",
+  "rawPayload": "Ham veri",
   "removeAddress": "Adresi kaldır",
   "replyDigest": "Yanıt özeti",
   "resetFilters": "Filtreleri sıfırla",

--- a/public/locales/vi/network-page.json
+++ b/public/locales/vi/network-page.json
@@ -185,6 +185,7 @@
   "rank": "Hạng",
   "remaining": "Còn lại",
   "remainingAmount": "Số tiền còn lại",
+  "rawPayload": "Dữ liệu thô",
   "removeAddress": "Xóa địa chỉ",
   "replyDigest": "Tóm tắt phản hồi",
   "resetFilters": "Đặt lại bộ lọc",

--- a/public/locales/zh/network-page.json
+++ b/public/locales/zh/network-page.json
@@ -185,6 +185,7 @@
   "rank": "排名",
   "remaining": "剩余",
   "remainingAmount": "剩余金额",
+  "rawPayload": "原始数据",
   "removeAddress": "删除地址",
   "replyDigest": "回复摘要",
   "resetFilters": "重置筛选",

--- a/src/pages/network/event-detail/EventDetailPage.tsx
+++ b/src/pages/network/event-detail/EventDetailPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 
 import { withHelmet } from '@app/components/hocs'
 import { Badge, Breadcrumbs } from '@app/components/ui'
+import { CopyTextButton } from '@app/components/ui/buttons'
 import { ErrorFallback } from '@app/components/ui/error-boundaries'
 import { PageLayout } from '@app/components/ui/layouts'
 import { LinearProgress } from '@app/components/ui/loaders'
@@ -156,7 +157,12 @@ function EventDetailPage() {
         <SubCardItem
           variant="secondary"
           title={t('logDigest')}
-          content={<p className="break-all font-space text-sm text-gray-50">{event.logDigest}</p>}
+          content={
+            <div className="flex min-w-0 flex-1 items-center gap-4">
+              <p className="break-all font-space text-sm text-gray-50">{event.logDigest}</p>
+              <CopyTextButton text={event.logDigest} />
+            </div>
+          }
         />
 
         {event.source && (
@@ -318,6 +324,18 @@ function EventDetailPage() {
             title={t('remainingAmount')}
             content={
               <p className="font-space text-sm">{formatString(event.remainingAmount)} QUBIC</p>
+            }
+          />
+        )}
+        {event.rawPayload && (
+          <SubCardItem
+            variant="secondary"
+            title={t('rawPayload')}
+            content={
+              <div className="flex min-w-0 flex-1 items-center gap-4">
+                <p className="break-all font-space text-sm text-gray-50">{event.rawPayload}</p>
+                <CopyTextButton text={event.rawPayload} />
+              </div>
             }
           />
         )}

--- a/src/store/apis/events/events.types.ts
+++ b/src/store/apis/events/events.types.ts
@@ -30,6 +30,7 @@ export type TransactionEvent = {
   remainingAmount?: number
   value?: string
   contractMessageType?: number
+  rawPayload?: string
 }
 
 // Log type numeric codes (from core/src/logging.h)
@@ -263,6 +264,7 @@ export interface RawApiEvent {
   assetOwnershipManagingContractChange?: AssetOwnershipManagingContractChangeData
   assetPossessionManagingContractChange?: AssetPossessionManagingContractChangeData
   smartContractMessage?: SmartContractMessageData
+  rawPayload?: string
 }
 
 export interface RawGetEventsResponse {
@@ -388,6 +390,10 @@ export function adaptApiEvent(raw: RawApiEvent): TransactionEvent {
   if (raw.smartContractMessage) {
     base.contractIndex = Number(raw.smartContractMessage.contractIndex)
     base.contractMessageType = Number(raw.smartContractMessage.contractMessageType)
+  }
+
+  if (raw.rawPayload) {
+    base.rawPayload = raw.rawPayload
   }
 
   return base


### PR DESCRIPTION
## Summary
- Display `rawPayload` field at the bottom of the event detail page when available
- Add copy buttons to `logDigest` and `rawPayload` fields
- Add `rawPayload` i18n translations for all 12 locales