### PR TITLE
feat: sync transaction filters to URL search params

### DIFF
--- a/src/pages/network/address/AddressPage.tsx
+++ b/src/pages/network/address/AddressPage.tsx
@@ -20,6 +20,7 @@ import { useGetSmartContractsQuery } from '@app/store/apis/qubic-static'
 import { clsxTwMerge, formatEllipsis, formatString, isValidQubicAddress } from '@app/utils'
 import { useGetAddressName } from '@app/hooks'
 import { HomeLink } from '../components'
+import { clearFilterParams } from '../utils/txFilterParams'
 import {
   AddressDetails,
   AddressEvents,
@@ -99,12 +100,14 @@ function AddressPage() {
     return 0
   }, [tabParam, isSmartContract])
 
-  // Normalize invalid tab params so URL always reflects the visible tab
+  // Normalize invalid tab params (e.g. ?tab=contract on a non-smart-contract address)
   useEffect(() => {
+    if (!tabParam) return
     const isValidTab =
+      tabParam === 'transactions' ||
       tabParam === 'events' ||
       ((tabParam === 'reserve' || tabParam === 'contract') && isSmartContract)
-    if (tabParam && !isValidTab) {
+    if (!isValidTab) {
       setSearchParams(
         (prev) => {
           prev.delete('tab')
@@ -117,17 +120,17 @@ function AddressPage() {
 
   const handleTabChange = useCallback(
     (index: number) => {
+      const tabMap: Record<number, string> = {
+        0: 'transactions',
+        1: 'events',
+        2: 'contract',
+        3: 'reserve'
+      }
       setSearchParams(
         (prev) => {
-          if (index === 1) {
-            prev.set('tab', 'events')
-          } else if (index === 2) {
-            prev.set('tab', 'contract')
-          } else if (index === 3) {
-            prev.set('tab', 'reserve')
-          } else {
-            prev.delete('tab')
-          }
+          // Clear all filter params when switching tabs
+          clearFilterParams(prev)
+          prev.set('tab', tabMap[index] ?? 'transactions')
           return prev
         },
         { replace: true }

--- a/src/pages/network/address/components/TransactionsOverview/LatestTransactions.tsx
+++ b/src/pages/network/address/components/TransactionsOverview/LatestTransactions.tsx
@@ -1,12 +1,15 @@
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 
 import { Infocon } from '@app/assets/icons'
 import { PageSizeSelect, PaginationBar, Tooltip } from '@app/components/ui'
-import type { Option } from '@app/components/ui/Select'
-import { DEFAULT_PAGE_SIZE } from '@app/constants'
+import { usePaginationSearchParams, useValidatedPage, useValidatedPageSize } from '@app/hooks'
 import useLatestTransactions, { MAX_TRANSACTION_RESULTS } from '../../hooks/useLatestTransactions'
+import type { TransactionFilters } from '../../hooks/useLatestTransactions'
 import { TransactionRow, TransactionSkeletonRow } from '../../../components'
+import { parseTransactionFilters, txFiltersToParams } from '../../../utils/txFilterParams'
+import { updateSearchParams } from '../../../utils/filterUtils'
 import { parseFilterApiError } from './filterUtils'
 import TransactionFiltersBar from './TransactionFiltersBar'
 
@@ -27,11 +30,26 @@ type Props = {
 
 export default function LatestTransactions({ addressId }: Props) {
   const { t } = useTranslation('network-page')
-  const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { handlePageChange, handlePageSizeChange } = usePaginationSearchParams()
+  const page = useValidatedPage()
+  const pageSize = useValidatedPageSize()
 
-  const { transactions, totalCount, isLoading, error, applyFilters, clearFilters, activeFilters } =
-    useLatestTransactions(addressId, page, pageSize)
+  // Read filters from URL search params (source of truth)
+  // Stabilize reference: only produce a new object when the serialized filter values actually change
+  // (useLatestTransactions uses useEffect with activeFilters as a dep, so reference stability matters)
+  const filtersJson = useMemo(
+    () => JSON.stringify(parseTransactionFilters(searchParams)),
+    [searchParams]
+  )
+  const activeFilters: TransactionFilters = useMemo(() => JSON.parse(filtersJson), [filtersJson])
+
+  const { transactions, totalCount, isLoading, error } = useLatestTransactions(
+    addressId,
+    page,
+    pageSize,
+    activeFilters
+  )
 
   // Parse API error to show localized message
   const errorMessage = useMemo(() => {
@@ -45,27 +63,25 @@ export default function LatestTransactions({ addressId }: Props) {
 
   const pageCount = totalCount !== null ? Math.ceil(totalCount / pageSize) : 0
 
-  const handlePageChange = useCallback((value: number) => {
-    setPage(value)
-  }, [])
-
-  const handlePageSizeChange = useCallback((option: Option) => {
-    setPageSize(parseInt(option.value, 10))
-    setPage(1)
-  }, [])
+  // Clamp page to valid range when it exceeds pageCount (e.g. manually edited URL)
+  useEffect(() => {
+    if (pageCount > 0 && page > pageCount) {
+      handlePageChange(pageCount)
+    }
+  }, [page, pageCount, handlePageChange])
 
   const handleApplyFilters = useCallback(
-    (filters: Parameters<typeof applyFilters>[0]) => {
-      applyFilters(filters)
-      setPage(1)
+    (filters: TransactionFilters) => {
+      setSearchParams((prev) => updateSearchParams(prev, txFiltersToParams(filters)), {
+        replace: true
+      })
     },
-    [applyFilters]
+    [setSearchParams]
   )
 
   const handleClearFilters = useCallback(() => {
-    clearFilters()
-    setPage(1)
-  }, [clearFilters])
+    setSearchParams((prev) => updateSearchParams(prev, txFiltersToParams({})), { replace: true })
+  }, [setSearchParams])
 
   const renderTableContent = useCallback(() => {
     if (isLoading) {

--- a/src/pages/network/address/hooks/useLatestTransactions.ts
+++ b/src/pages/network/address/hooks/useLatestTransactions.ts
@@ -27,20 +27,17 @@ export interface UseLatestTransactionsResult {
   totalCount: number | null
   isLoading: boolean
   error: string | null
-  applyFilters: (filters: TransactionFilters) => void
-  clearFilters: () => void
-  activeFilters: TransactionFilters
 }
 
 export default function useLatestTransactions(
   addressId: string,
   page: number,
-  pageSize: number
+  pageSize: number,
+  activeFilters: TransactionFilters
 ): UseLatestTransactionsResult {
   const [transactions, setTransactions] = useState<QueryServiceTransaction[]>([])
   const [totalCount, setTotalCount] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [activeFilters, setActiveFilters] = useState<TransactionFilters>({})
   const cancellationRef = useRef(false)
 
   const [getTransactionsForIdentity, { error }] = useGetTransactionsForIdentityMutation()
@@ -143,14 +140,6 @@ export default function useLatestTransactions(
     [getTransactionsForIdentity, addressId]
   )
 
-  const applyFilters = useCallback((filters: TransactionFilters) => {
-    setActiveFilters(filters)
-  }, [])
-
-  const clearFilters = useCallback(() => {
-    setActiveFilters({})
-  }, [])
-
   // Fetch the requested page whenever page, pageSize, filters, or addressId change
   useEffect(() => {
     cancellationRef.current = false
@@ -184,9 +173,6 @@ export default function useLatestTransactions(
     transactions,
     totalCount,
     isLoading,
-    error: extractErrorMessage(error),
-    applyFilters,
-    clearFilters,
-    activeFilters
+    error: extractErrorMessage(error)
   }
 }

--- a/src/pages/network/tick/TickPage.tsx
+++ b/src/pages/network/tick/TickPage.tsx
@@ -7,7 +7,10 @@ import { Breadcrumbs, Tabs } from '@app/components/ui'
 import { PageLayout } from '@app/components/ui/layouts'
 import { formatString } from '@app/utils'
 import { HomeLink } from '../components'
+import { clearFilterParams } from '../utils/txFilterParams'
 import { TickDetails, TickEvents, TickTransactions } from './components'
+
+const TAB_VALUES = ['transactions', 'events'] as const
 
 function TickPage() {
   const { t } = useTranslation('network-page')
@@ -22,7 +25,15 @@ function TickPage() {
 
   const handleTabChange = useCallback(
     (index: number) => {
-      setSearchParams(index === 1 ? { tab: 'events' } : {}, { replace: true })
+      setSearchParams(
+        (prev) => {
+          // Clear all filter params when switching tabs
+          clearFilterParams(prev)
+          prev.set('tab', TAB_VALUES[index] ?? 'transactions')
+          return prev
+        },
+        { replace: true }
+      )
     },
     [setSearchParams]
   )

--- a/src/pages/network/tick/components/TickTransactions.tsx
+++ b/src/pages/network/tick/components/TickTransactions.tsx
@@ -1,9 +1,12 @@
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 
 import { PageSizeSelect, PaginationBar } from '@app/components/ui'
 import { usePaginationSearchParams, useValidatedPage, useValidatedPageSize } from '@app/hooks'
 import { useGetTransactionsForTickQuery } from '@app/store/apis/query-service'
+import { parseTickTransactionFilters, tickTxFiltersToParams } from '../../utils/txFilterParams'
+import { updateSearchParams } from '../../utils/filterUtils'
 import TickTransactionFiltersBar from './TickTransactionFiltersBar'
 import { TransactionRow, TransactionSkeletonRow } from '../../components'
 import type { TickTransactionFilters } from './tickFilterUtils'
@@ -29,10 +32,14 @@ type Props = Readonly<{
 
 export default function TickTransactions({ tick }: Props) {
   const { t } = useTranslation('network-page')
-  const [activeFilters, setActiveFilters] = useState<TickTransactionFilters>({})
-  const { handlePageChange, handlePageSizeChange, resetPage } = usePaginationSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { handlePageChange, handlePageSizeChange } = usePaginationSearchParams()
   const page = useValidatedPage()
   const pageSize = useValidatedPageSize()
+
+  // Read filters from URL search params (source of truth)
+  // No reference stabilization needed: RTK Query caches by serialized args, not by reference
+  const activeFilters = useMemo(() => parseTickTransactionFilters(searchParams), [searchParams])
 
   // Build the API request with filters
   const request = useMemo(
@@ -66,6 +73,13 @@ export default function TickTransactions({ tick }: Props) {
   const totalCount = transactions?.length ?? 0
   const pageCount = Math.ceil(totalCount / pageSize)
 
+  // Clamp page to valid range when it exceeds pageCount (e.g. manually edited URL)
+  useEffect(() => {
+    if (pageCount > 0 && page > pageCount) {
+      handlePageChange(pageCount)
+    }
+  }, [page, pageCount, handlePageChange])
+
   const paginatedTransactions = useMemo(() => {
     if (!transactions) return []
     const start = (page - 1) * pageSize
@@ -74,16 +88,18 @@ export default function TickTransactions({ tick }: Props) {
 
   const handleApplyFilters = useCallback(
     (filters: TickTransactionFilters) => {
-      setActiveFilters(filters)
-      resetPage()
+      setSearchParams((prev) => updateSearchParams(prev, tickTxFiltersToParams(filters)), {
+        replace: true
+      })
     },
-    [resetPage]
+    [setSearchParams]
   )
 
   const handleClearFilters = useCallback(() => {
-    setActiveFilters({})
-    resetPage()
-  }, [resetPage])
+    setSearchParams((prev) => updateSearchParams(prev, tickTxFiltersToParams({})), {
+      replace: true
+    })
+  }, [setSearchParams])
 
   const renderTableContent = useCallback(() => {
     if (isTickTransactionsLoading) {

--- a/src/pages/network/utils/txFilterParams.ts
+++ b/src/pages/network/utils/txFilterParams.ts
@@ -1,0 +1,179 @@
+import { isValidAddressFormat } from '@app/utils'
+import type {
+  AddressFilter,
+  TransactionFilters
+} from '../address/components/TransactionsOverview/filterUtils'
+import type { TickTransactionFilters } from '../tick/components/tickFilterUtils'
+import { parseAddressFilter, parseDateRange, parseTickRange } from './eventFilterUtils'
+
+// ============================================================================
+// FILTER PARAM CLEARING (for tab switches)
+// ============================================================================
+
+/** Params that should persist across tab switches (not filter-related). */
+const PRESERVED_PARAMS = new Set(['tab', 'pageSize'])
+
+/**
+ * Removes all filter-related search params from the given URLSearchParams.
+ * Preserves `tab` and `pageSize` (user preferences, not filters).
+ */
+export function clearFilterParams(params: URLSearchParams): void {
+  Array.from(params.keys()).forEach((key) => {
+    if (!PRESERVED_PARAMS.has(key)) params.delete(key)
+  })
+}
+
+// ============================================================================
+// URL → TRANSACTION FILTERS (parsing)
+// ============================================================================
+
+/** Returns value only if it's a valid non-negative integer string. */
+function parseNumericParam(value: string | null): string | undefined {
+  if (!value) return undefined
+  return /^\d+$/.test(value) ? value : undefined
+}
+
+/** Validates addresses in a parsed AddressFilter, keeping only valid-format ones. */
+function validateAddressFilter(filter: AddressFilter | undefined): AddressFilter | undefined {
+  if (!filter) return undefined
+  const valid = filter.addresses.filter((addr) => isValidAddressFormat(addr))
+  if (valid.length === 0) return undefined
+  return { ...filter, addresses: valid }
+}
+
+/**
+ * Parses amount range from URL search params.
+ * Reads: amountMin, amountMax, amountPreset
+ */
+function parseTxAmountRange(
+  searchParams: URLSearchParams
+): TransactionFilters['amountRange'] | undefined {
+  const min = parseNumericParam(searchParams.get('amountMin'))
+  const max = parseNumericParam(searchParams.get('amountMax'))
+  const presetKey = searchParams.get('amountPreset') || undefined
+  if (!min && !max && !presetKey) return undefined
+  return { start: min, end: max, presetKey }
+}
+
+/**
+ * Parses input type range from URL search params.
+ * Reads: inputTypeMin, inputTypeMax
+ */
+function parseTxInputTypeRange(
+  searchParams: URLSearchParams
+): TransactionFilters['inputTypeRange'] | undefined {
+  const min = parseNumericParam(searchParams.get('inputTypeMin'))
+  const max = parseNumericParam(searchParams.get('inputTypeMax'))
+  if (!min && !max) return undefined
+  return { start: min, end: max }
+}
+
+/**
+ * Parses all address-page transaction filters from URL search params.
+ */
+export function parseTransactionFilters(searchParams: URLSearchParams): TransactionFilters {
+  const direction = searchParams.get('direction') as TransactionFilters['direction'] | null
+  const sourceFilter = validateAddressFilter(
+    parseAddressFilter(searchParams, 'source', 'sourceMode')
+  )
+  const destinationFilter = validateAddressFilter(
+    parseAddressFilter(searchParams, 'destination', 'destMode')
+  )
+  const amountRange = parseTxAmountRange(searchParams)
+  const inputTypeRange = parseTxInputTypeRange(searchParams)
+  const { start: tickStart, end: tickEnd } = parseTickRange(searchParams)
+  const tickNumberRange = tickStart || tickEnd ? { start: tickStart, end: tickEnd } : undefined
+  const dateRange = parseDateRange(searchParams)
+
+  const filters: TransactionFilters = {}
+  if (direction === 'incoming' || direction === 'outgoing') filters.direction = direction
+  if (sourceFilter) filters.sourceFilter = sourceFilter
+  if (destinationFilter) filters.destinationFilter = destinationFilter
+  if (amountRange) filters.amountRange = amountRange
+  if (inputTypeRange) filters.inputTypeRange = inputTypeRange
+  if (tickNumberRange) filters.tickNumberRange = tickNumberRange
+  if (dateRange) filters.dateRange = dateRange
+  return filters
+}
+
+/**
+ * Parses tick-page transaction filters from URL search params.
+ * Tick page uses simpler single-address filters (no multi-address, no direction/date/tick range).
+ */
+export function parseTickTransactionFilters(searchParams: URLSearchParams): TickTransactionFilters {
+  const rawSource = searchParams.get('source') || undefined
+  const rawDest = searchParams.get('destination') || undefined
+  const source = rawSource && isValidAddressFormat(rawSource) ? rawSource : undefined
+  const destination = rawDest && isValidAddressFormat(rawDest) ? rawDest : undefined
+  const amountRange = parseTxAmountRange(searchParams)
+  const inputTypeRange = parseTxInputTypeRange(searchParams)
+
+  const filters: TickTransactionFilters = {}
+  if (source) filters.source = source
+  if (destination) filters.destination = destination
+  if (amountRange) filters.amountRange = amountRange
+  if (inputTypeRange) filters.inputTypeRange = inputTypeRange
+  return filters
+}
+
+// ============================================================================
+// TRANSACTION FILTERS → URL PARAMS (serialization)
+// ============================================================================
+
+/**
+ * Converts address-page transaction filters to URL param record.
+ * Undefined values signal "remove this param".
+ */
+export function txFiltersToParams(filters: TransactionFilters): Record<string, string | undefined> {
+  const params: Record<string, string | undefined> = {
+    direction: filters.direction ?? undefined,
+    // Source
+    source: filters.sourceFilter?.addresses.filter((a) => a.trim()).join(',') || undefined,
+    sourceMode:
+      filters.sourceFilter?.addresses.some((a) => a.trim()) &&
+      filters.sourceFilter?.mode === 'exclude'
+        ? 'exclude'
+        : undefined,
+    // Destination
+    destination:
+      filters.destinationFilter?.addresses.filter((a) => a.trim()).join(',') || undefined,
+    destMode:
+      filters.destinationFilter?.addresses.some((a) => a.trim()) &&
+      filters.destinationFilter?.mode === 'exclude'
+        ? 'exclude'
+        : undefined,
+    // Amount
+    amountMin: filters.amountRange?.start ?? undefined,
+    amountMax: filters.amountRange?.end ?? undefined,
+    amountPreset: filters.amountRange?.presetKey ?? undefined,
+    // Input type
+    inputTypeMin: filters.inputTypeRange?.start ?? undefined,
+    inputTypeMax: filters.inputTypeRange?.end ?? undefined,
+    // Tick range
+    tickStart: filters.tickNumberRange?.start ?? undefined,
+    tickEnd: filters.tickNumberRange?.end ?? undefined,
+    // Date range
+    dateStart: filters.dateRange?.start ?? undefined,
+    dateEnd: filters.dateRange?.end ?? undefined,
+    datePresetDays:
+      filters.dateRange?.presetDays !== undefined ? String(filters.dateRange.presetDays) : undefined
+  }
+  return params
+}
+
+/**
+ * Converts tick-page transaction filters to URL param record.
+ */
+export function tickTxFiltersToParams(
+  filters: TickTransactionFilters
+): Record<string, string | undefined> {
+  return {
+    source: filters.source?.trim() || undefined,
+    destination: filters.destination?.trim() || undefined,
+    amountMin: filters.amountRange?.start ?? undefined,
+    amountMax: filters.amountRange?.end ?? undefined,
+    amountPreset: filters.amountRange?.presetKey ?? undefined,
+    inputTypeMin: filters.inputTypeRange?.start ?? undefined,
+    inputTypeMax: filters.inputTypeRange?.end ?? undefined
+  }
+}


### PR DESCRIPTION
Move transaction filter state from component-level useState to URL search params on both tick and address pages, matching the existing event filter pattern. Filters now persist on refresh and are shareable via URL.

- Add txFilterParams.ts with URL parsing/serialization utilities
- Validate URL inputs (address format, integer-only numerics, direction)
- Clear filter params on tab switch, preserve tab and pageSize
- Stabilize activeFilters reference for useLatestTransactions (useEffect dep)
- Clamp page to valid range when it exceeds pageCount