### PR TITLE
feat: add support for log types 14 and 15 in events

### DIFF
--- a/public/locales/ar/network-page.json
+++ b/public/locales/ar/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "تحويلات QUBIC",
   "rangeType": "نوع النطاق",
   "tickRange": "نطاق التك",
-  "tokenTransfers": "تحويلات الرموز"
+  "tokenTransfers": "تحويلات الرموز",
+  "queryType": "نوع الاستعلام",
+  "queryStatus": "حالة الاستعلام",
+  "interfaceIndex": "فهرس الواجهة",
+  "subscriptionId": "معرف الاشتراك",
+  "periodMillis": "الفترة (مللي ثانية)",
+  "firstQueryTimestamp": "تاريخ أول استعلام",
+  "queryingEntity": "الكيان المُستعلِم"
 }

--- a/public/locales/de/network-page.json
+++ b/public/locales/de/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC-Überweisungen",
   "rangeType": "Bereichstyp",
   "tickRange": "Tick-Bereich",
-  "tokenTransfers": "Token-Überweisungen"
+  "tokenTransfers": "Token-Überweisungen",
+  "queryType": "Abfragetyp",
+  "queryStatus": "Abfragestatus",
+  "interfaceIndex": "Schnittstellenindex",
+  "subscriptionId": "Abonnement-ID",
+  "periodMillis": "Periode (ms)",
+  "firstQueryTimestamp": "Erstes Abfragedatum",
+  "queryingEntity": "Anfragende Entität"
 }

--- a/public/locales/en/network-page.json
+++ b/public/locales/en/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC Transfers",
   "rangeType": "Range Type",
   "tickRange": "Tick Range",
-  "tokenTransfers": "Token Transfers"
+  "tokenTransfers": "Token Transfers",
+  "queryType": "Query Type",
+  "queryStatus": "Query Status",
+  "interfaceIndex": "Interface Index",
+  "subscriptionId": "Subscription ID",
+  "periodMillis": "Period (ms)",
+  "firstQueryTimestamp": "First Query Date",
+  "queryingEntity": "Querying Entity"
 }

--- a/public/locales/es/network-page.json
+++ b/public/locales/es/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "Transferencias QUBIC",
   "rangeType": "Tipo de rango",
   "tickRange": "Rango de ticks",
-  "tokenTransfers": "Transferencias de tokens"
+  "tokenTransfers": "Transferencias de tokens",
+  "queryType": "Tipo de consulta",
+  "queryStatus": "Estado de consulta",
+  "interfaceIndex": "Índice de interfaz",
+  "subscriptionId": "ID de suscripción",
+  "periodMillis": "Período (ms)",
+  "firstQueryTimestamp": "Fecha de primera consulta",
+  "queryingEntity": "Entidad consultante"
 }

--- a/public/locales/fr/network-page.json
+++ b/public/locales/fr/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "Transferts QUBIC",
   "rangeType": "Type de plage",
   "tickRange": "Plage de ticks",
-  "tokenTransfers": "Transferts de jetons"
+  "tokenTransfers": "Transferts de jetons",
+  "queryType": "Type de requête",
+  "queryStatus": "Statut de la requête",
+  "interfaceIndex": "Index d'interface",
+  "subscriptionId": "ID d'abonnement",
+  "periodMillis": "Période (ms)",
+  "firstQueryTimestamp": "Date de première requête",
+  "queryingEntity": "Entité requêtante"
 }

--- a/public/locales/ja/network-page.json
+++ b/public/locales/ja/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC送金",
   "rangeType": "範囲タイプ",
   "tickRange": "ティック範囲",
-  "tokenTransfers": "トークン送金"
+  "tokenTransfers": "トークン送金",
+  "queryType": "クエリタイプ",
+  "queryStatus": "クエリステータス",
+  "interfaceIndex": "インターフェースインデックス",
+  "subscriptionId": "サブスクリプションID",
+  "periodMillis": "期間（ミリ秒）",
+  "firstQueryTimestamp": "最初のクエリ日時",
+  "queryingEntity": "クエリ実行エンティティ"
 }

--- a/public/locales/nl/network-page.json
+++ b/public/locales/nl/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC-overdrachten",
   "rangeType": "Bereiktype",
   "tickRange": "Tick-bereik",
-  "tokenTransfers": "Token-overdrachten"
+  "tokenTransfers": "Token-overdrachten",
+  "queryType": "Querytype",
+  "queryStatus": "Querystatus",
+  "interfaceIndex": "Interface-index",
+  "subscriptionId": "Abonnement-ID",
+  "periodMillis": "Periode (ms)",
+  "firstQueryTimestamp": "Datum eerste query",
+  "queryingEntity": "Query-uitvoerende entiteit"
 }

--- a/public/locales/pt/network-page.json
+++ b/public/locales/pt/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "Transferências QUBIC",
   "rangeType": "Tipo de intervalo",
   "tickRange": "Intervalo de ticks",
-  "tokenTransfers": "Transferências de tokens"
+  "tokenTransfers": "Transferências de tokens",
+  "queryType": "Tipo de consulta",
+  "queryStatus": "Estado da consulta",
+  "interfaceIndex": "Índice de interface",
+  "subscriptionId": "ID da subscrição",
+  "periodMillis": "Período (ms)",
+  "firstQueryTimestamp": "Data da primeira consulta",
+  "queryingEntity": "Entidade consultante"
 }

--- a/public/locales/ru/network-page.json
+++ b/public/locales/ru/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "Переводы QUBIC",
   "rangeType": "Тип диапазона",
   "tickRange": "Диапазон тиков",
-  "tokenTransfers": "Переводы токенов"
+  "tokenTransfers": "Переводы токенов",
+  "queryType": "Тип запроса",
+  "queryStatus": "Статус запроса",
+  "interfaceIndex": "Индекс интерфейса",
+  "subscriptionId": "ID подписки",
+  "periodMillis": "Период (мс)",
+  "firstQueryTimestamp": "Дата первого запроса",
+  "queryingEntity": "Запрашивающая сущность"
 }

--- a/public/locales/tr/network-page.json
+++ b/public/locales/tr/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC Transferleri",
   "rangeType": "Aralık türü",
   "tickRange": "Tick aralığı",
-  "tokenTransfers": "Token Transferleri"
+  "tokenTransfers": "Token Transferleri",
+  "queryType": "Sorgu türü",
+  "queryStatus": "Sorgu durumu",
+  "interfaceIndex": "Arayüz dizini",
+  "subscriptionId": "Abonelik kimliği",
+  "periodMillis": "Süre (ms)",
+  "firstQueryTimestamp": "İlk sorgu tarihi",
+  "queryingEntity": "Sorgulayan varlık"
 }

--- a/public/locales/vi/network-page.json
+++ b/public/locales/vi/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "Chuyển QUBIC",
   "rangeType": "Loại phạm vi",
   "tickRange": "Khoảng tick",
-  "tokenTransfers": "Chuyển token"
+  "tokenTransfers": "Chuyển token",
+  "queryType": "Loại truy vấn",
+  "queryStatus": "Trạng thái truy vấn",
+  "interfaceIndex": "Chỉ mục giao diện",
+  "subscriptionId": "ID đăng ký",
+  "periodMillis": "Chu kỳ (ms)",
+  "firstQueryTimestamp": "Ngày truy vấn đầu tiên",
+  "queryingEntity": "Thực thể truy vấn"
 }

--- a/public/locales/zh/network-page.json
+++ b/public/locales/zh/network-page.json
@@ -281,5 +281,12 @@
   "qubicTransfers": "QUBIC转账",
   "rangeType": "范围类型",
   "tickRange": "Tick范围",
-  "tokenTransfers": "代币转账"
+  "tokenTransfers": "代币转账",
+  "queryType": "查询类型",
+  "queryStatus": "查询状态",
+  "interfaceIndex": "接口索引",
+  "subscriptionId": "订阅ID",
+  "periodMillis": "周期（毫秒）",
+  "firstQueryTimestamp": "首次查询日期",
+  "queryingEntity": "查询实体"
 }

--- a/src/pages/network/event-detail/EventDetailPage.tsx
+++ b/src/pages/network/event-detail/EventDetailPage.tsx
@@ -12,7 +12,9 @@ import { useGetAddressName, useGetSmartContractByIndex } from '@app/hooks'
 import {
   useGetEventsQuery,
   getEventTypeLabel,
-  getLastProcessedTickFromEventsError
+  getLastProcessedTickFromEventsError,
+  ORACLE_QUERY_STATUS_LABELS,
+  ORACLE_QUERY_TYPE_LABELS
 } from '@app/store/apis/events'
 import { formatDate, formatString } from '@app/utils'
 import { AddressLink, HomeLink, SubCardItem, TickLink, TxLink, VirtualTxLink } from '../components'
@@ -39,6 +41,7 @@ function EventDetailPage() {
 
   const ownerAddressName = useGetAddressName(event?.owner ?? '')
   const possessorAddressName = useGetAddressName(event?.possessor ?? '')
+  const queryingEntityName = useGetAddressName(event?.queryingEntity ?? '')
 
   const contract = useGetSmartContractByIndex(
     event?.contractIndex && event.contractIndex > 0 ? event.contractIndex : undefined
@@ -324,6 +327,94 @@ function EventDetailPage() {
             title={t('remainingAmount')}
             content={
               <p className="font-space text-sm">{formatString(event.remainingAmount)} QUBIC</p>
+            }
+          />
+        )}
+        {event.queryingEntity && (
+          <SubCardItem
+            variant="secondary"
+            title={t('queryingEntity')}
+            content={
+              <AddressLink
+                value={event.queryingEntity}
+                label={queryingEntityName?.name}
+                copy
+                showTooltip={!!queryingEntityName?.name}
+              />
+            }
+          />
+        )}
+        {event.queryId !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('queryId')}
+            content={
+              <div className="flex min-w-0 flex-1 items-center gap-4">
+                <p className="break-all font-space text-sm">{event.queryId}</p>
+                <CopyTextButton text={event.queryId} />
+              </div>
+            }
+          />
+        )}
+        {event.queryType !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('queryType')}
+            content={
+              <p className="font-space text-sm">
+                {event.queryType}
+                <span className="text-gray-50">
+                  {' '}
+                  ({ORACLE_QUERY_TYPE_LABELS[event.queryType] ?? 'UNKNOWN'})
+                </span>
+              </p>
+            }
+          />
+        )}
+        {event.queryStatus !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('queryStatus')}
+            content={
+              <p className="font-space text-sm">
+                {event.queryStatus}
+                <span className="text-gray-50">
+                  {' '}
+                  ({ORACLE_QUERY_STATUS_LABELS[event.queryStatus] ?? 'UNKNOWN'})
+                </span>
+              </p>
+            }
+          />
+        )}
+        {event.interfaceIndex !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('interfaceIndex')}
+            content={<p className="font-space text-sm">{event.interfaceIndex}</p>}
+          />
+        )}
+        {event.subscriptionId !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('subscriptionId')}
+            content={<p className="break-all font-space text-sm">{event.subscriptionId}</p>}
+          />
+        )}
+        {event.periodMillis !== undefined && (
+          <SubCardItem
+            variant="secondary"
+            title={t('periodMillis')}
+            content={<p className="font-space text-sm">{formatString(event.periodMillis)}</p>}
+          />
+        )}
+        {event.firstQueryTimestamp && (
+          <SubCardItem
+            variant="secondary"
+            title={t('firstQueryTimestamp')}
+            content={
+              <p className="font-space text-sm">
+                {formatDate(event.firstQueryTimestamp) || event.firstQueryTimestamp}
+              </p>
             }
           />
         )}

--- a/src/store/apis/events/events.types.ts
+++ b/src/store/apis/events/events.types.ts
@@ -31,6 +31,31 @@ export type TransactionEvent = {
   value?: string
   contractMessageType?: number
   rawPayload?: string
+  // Oracle event fields
+  queryingEntity?: string
+  queryId?: string
+  interfaceIndex?: number
+  queryType?: number
+  queryStatus?: number
+  subscriptionId?: string
+  periodMillis?: number
+  firstQueryTimestamp?: string
+}
+
+// Oracle query type values (from core: ORACLE_QUERY_TYPE_*)
+export const ORACLE_QUERY_TYPE_LABELS: Record<number, string> = {
+  0: 'CONTRACT_QUERY',
+  1: 'CONTRACT_SUBSCRIPTION',
+  2: 'USER_QUERY'
+}
+
+// Oracle query status values (from core: ORACLE_QUERY_STATUS_*)
+export const ORACLE_QUERY_STATUS_LABELS: Record<number, string> = {
+  1: 'PENDING',
+  2: 'COMMITTED',
+  3: 'SUCCESS',
+  4: 'TIMEOUT',
+  5: 'UNRESOLVABLE'
 }
 
 // Log type numeric codes (from core/src/logging.h)
@@ -50,11 +75,11 @@ export const EVENT_TYPES = {
   ASSET_POSSESSION_MANAGING_CONTRACT_CHANGE: 12,
   CONTRACT_RESERVE_DEDUCTION: 13,
   ORACLE_QUERY_STATUS_CHANGE: 14,
+  ORACLE_SUBSCRIBER_MESSAGE: 15,
   CUSTOM_MESSAGE: 255
 } as const
 
 // Event types supported by the events API for filtering.
-// ORACLE_QUERY_STATUS_CHANGE (14) is excluded — not yet supported by the events API.
 export const EVENT_TYPE_FILTER_OPTIONS = [
   EVENT_TYPES.QU_TRANSFER,
   EVENT_TYPES.ASSET_ISSUANCE,
@@ -70,6 +95,8 @@ export const EVENT_TYPE_FILTER_OPTIONS = [
   EVENT_TYPES.ASSET_OWNERSHIP_MANAGING_CONTRACT_CHANGE,
   EVENT_TYPES.ASSET_POSSESSION_MANAGING_CONTRACT_CHANGE,
   EVENT_TYPES.CONTRACT_RESERVE_DEDUCTION,
+  EVENT_TYPES.ORACLE_QUERY_STATUS_CHANGE,
+  EVENT_TYPES.ORACLE_SUBSCRIBER_MESSAGE,
   EVENT_TYPES.CUSTOM_MESSAGE
 ] as const
 
@@ -91,6 +118,7 @@ export const EVENT_TYPE_LABELS: Record<number, string> = {
     'ASSET_POSSESSION_MANAGING_CONTRACT_CHANGE',
   [EVENT_TYPES.CONTRACT_RESERVE_DEDUCTION]: 'CONTRACT_RESERVE_DEDUCTION',
   [EVENT_TYPES.ORACLE_QUERY_STATUS_CHANGE]: 'ORACLE_QUERY_STATUS_CHANGE',
+  [EVENT_TYPES.ORACLE_SUBSCRIBER_MESSAGE]: 'ORACLE_SUBSCRIBER_MESSAGE',
   [EVENT_TYPES.CUSTOM_MESSAGE]: 'CUSTOM_MESSAGE'
 }
 
@@ -243,6 +271,22 @@ interface SmartContractMessageData {
   contractMessageType: string
 }
 
+interface OracleQueryStatusChangeData {
+  queryingEntity: string
+  queryId: string
+  interfaceIndex: string
+  queryType: string
+  queryStatus: string
+}
+
+interface OracleSubscriberLogMessageData {
+  subscriptionId: string
+  interfaceIndex: string
+  contractIndex: string
+  periodMillis: string
+  firstQueryTimestamp: string
+}
+
 export interface RawApiEvent {
   epoch: number
   tickNumber: number
@@ -264,6 +308,8 @@ export interface RawApiEvent {
   assetOwnershipManagingContractChange?: AssetOwnershipManagingContractChangeData
   assetPossessionManagingContractChange?: AssetPossessionManagingContractChangeData
   smartContractMessage?: SmartContractMessageData
+  oracleQueryStatusChange?: OracleQueryStatusChangeData
+  oracleSubscriberLogMessage?: OracleSubscriberLogMessageData
   rawPayload?: string
 }
 
@@ -385,6 +431,20 @@ export function adaptApiEvent(raw: RawApiEvent): TransactionEvent {
     base.remainingAmount = Number(raw.contractReserveDeduction.remainingAmount)
   } else if (raw.customMessage) {
     base.value = raw.customMessage.value
+  } else if (raw.oracleQueryStatusChange) {
+    const d = raw.oracleQueryStatusChange
+    base.queryingEntity = d.queryingEntity
+    base.queryId = d.queryId
+    base.interfaceIndex = Number(d.interfaceIndex)
+    base.queryType = Number(d.queryType)
+    base.queryStatus = Number(d.queryStatus)
+  } else if (raw.oracleSubscriberLogMessage) {
+    const d = raw.oracleSubscriberLogMessage
+    base.subscriptionId = d.subscriptionId
+    base.interfaceIndex = Number(d.interfaceIndex)
+    base.contractIndex = Number(d.contractIndex)
+    base.periodMillis = Number(d.periodMillis)
+    base.firstQueryTimestamp = d.firstQueryTimestamp
   }
 
   if (raw.smartContractMessage) {


### PR DESCRIPTION
Add ORACLE_QUERY_STATUS_CHANGE (14) and ORACLE_SUBSCRIBER_MESSAGE (15) as filterable event types. Display oracle-specific fields on the event detail page with descriptive labels for query type and status.

- Both types now selectable in the events filter dropdown
- Adapt oracleQueryStatusChange (queryingEntity, queryId, interfaceIndex, queryType, queryStatus) and oracleSubscriberLogMessage (subscriptionId, interfaceIndex, contractIndex, periodMillis, firstQueryTimestamp)
- Show descriptive labels for queryType (CONTRACT_QUERY, USER_QUERY, etc.) and queryStatus (PENDING, COMMITTED, SUCCESS, etc.)