### PR TITLE
fix(csv-export): guard against spreadsheet formula injection

### DIFF
--- a/src/pages/network/tools/csvUtils.ts
+++ b/src/pages/network/tools/csvUtils.ts
@@ -23,10 +23,12 @@ function formatCsvTimestamp(value: string | number): string {
 }
 
 function escapeCsvField(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`
+  // Prefix-guard against spreadsheet formula injection (=, +, -, @, tab, CR).
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+  if (guarded.includes(',') || guarded.includes('"') || guarded.includes('\n')) {
+    return `"${guarded.replace(/"/g, '""')}"`
   }
-  return value
+  return guarded
 }
 
 function toCsvRow(fields: string[]): string {


### PR DESCRIPTION
Prefix-guard CSV fields starting with =, +, -, @, tab, or CR with a single quote so that user-controlled values (e.g. token asset names) cannot be interpreted as formulas by Excel, Sheets, or LibreOffice when the exported file is opened.