### PR TITLE
feat(csv-export): add Direction column (IN/OUT/SELF)

### DIFF
--- a/src/pages/network/address/components/TransactionsOverview/LatestTransactions.tsx
+++ b/src/pages/network/address/components/TransactionsOverview/LatestTransactions.tsx
@@ -89,7 +89,13 @@ export default function LatestTransactions({ addressId }: Props) {
 
   const handleDownloadPageData = useCallback(() => {
     if (transactions.length === 0) return
-    const csv = transactionsToCsv(transactions, protocolData, smartContracts, tickIntervals)
+    const csv = transactionsToCsv(
+      transactions,
+      addressId,
+      protocolData,
+      smartContracts,
+      tickIntervals
+    )
     downloadCsv(csv, buildCsvFilename(`transactions_page${page}`, addressId))
   }, [transactions, protocolData, smartContracts, tickIntervals, addressId, page])
 

--- a/src/pages/network/tools/csvUtils.ts
+++ b/src/pages/network/tools/csvUtils.ts
@@ -45,8 +45,19 @@ function getTxStatusLabel(
   return moneyFlew ? 'Successful transfer' : 'Transfer failed'
 }
 
+function getDirection(source: string, destination: string, address: string): string {
+  const addr = address.toUpperCase()
+  const isSource = source.toUpperCase() === addr
+  const isDest = destination.toUpperCase() === addr
+  if (isSource && isDest) return 'SELF'
+  if (isSource) return 'OUT'
+  if (isDest) return 'IN'
+  return ''
+}
+
 export function transactionsToCsv(
   transactions: QueryServiceTransaction[],
+  address: string,
   protocolData?: TransactionInputType[],
   smartContracts?: SmartContract[],
   tickIntervals?: ProcessedTickInterval[]
@@ -55,6 +66,7 @@ export function transactionsToCsv(
     'Timestamp',
     'Tick',
     'TX ID',
+    'Direction',
     'Source',
     'Destination',
     'Amount',
@@ -85,6 +97,7 @@ export function transactionsToCsv(
       formatCsvTimestamp(tx.timestamp),
       String(tx.tickNumber),
       tx.hash,
+      getDirection(tx.source, tx.destination, address),
       tx.source,
       tx.destination,
       tx.amount,
@@ -97,11 +110,12 @@ export function transactionsToCsv(
   return [header, ...rows].join('\n')
 }
 
-export function eventsToCsv(events: TransactionEvent[]): string {
+export function eventsToCsv(events: TransactionEvent[], address: string): string {
   const header = toCsvRow([
     'Timestamp',
     'Tick',
     'TX ID',
+    'Direction',
     'Source',
     'Destination',
     'Amount',
@@ -113,6 +127,7 @@ export function eventsToCsv(events: TransactionEvent[]): string {
       formatCsvTimestamp(event.timestamp),
       String(event.tickNumber),
       event.transactionHash,
+      getDirection(event.source, event.destination, address),
       event.source,
       event.destination,
       event.amount !== undefined ? String(event.amount) : '',

--- a/src/pages/network/tools/useCsvExport.ts
+++ b/src/pages/network/tools/useCsvExport.ts
@@ -87,7 +87,13 @@ export default function useCsvExport() {
             return
           }
 
-          const csv = transactionsToCsv(transactions, protocolData, smartContracts, tickIntervals)
+          const csv = transactionsToCsv(
+            transactions,
+            address,
+            protocolData,
+            smartContracts,
+            tickIntervals
+          )
           downloadCsv(csv, buildCsvFilename('transactions', address))
         } else {
           // QUBIC Transfers (logType 0) or Token Transfers (logType 3)
@@ -108,7 +114,7 @@ export default function useCsvExport() {
             return
           }
 
-          const csv = eventsToCsv(result.events)
+          const csv = eventsToCsv(result.events, address)
           const typeLabel = exportType === 'qubicTransfers' ? 'qubic_transfers' : 'token_transfers'
           downloadCsv(csv, buildCsvFilename(typeLabel, address))
         }


### PR DESCRIPTION
Adds a Direction column to transaction and event CSV exports indicating whether the row is incoming, outgoing, or a self-transfer relative to the exported address.