### PR TITLE
fix(tx-page): reset state when navigating between transactions

### DIFF
--- a/src/pages/network/TxPage.tsx
+++ b/src/pages/network/TxPage.tsx
@@ -258,7 +258,10 @@ function TxPage() {
     return <VirtualTxContent txId={txId} virtualTx={virtualTx} />
   }
 
-  return <RegularTxContent txId={txId} />
+  // key={txId} forces a full remount when navigating between regular
+  // transactions so useTickWatcher refs/state cannot leak from the previous
+  // tx and leave the page showing stale data when the new tx 404s.
+  return <RegularTxContent key={txId} txId={txId} />
 }
 
 const TxPageWithHelmet = withHelmet(TxPage, {


### PR DESCRIPTION
Add key={txId} to RegularTxContent so React fully remounts the component when the URL :txId param changes. Without this, useTickWatcher refs and other hook state could leak from the previous transaction and leave the page showing stale data when the new transaction's getTransactionByHash request 404s (e.g. when its tick is in the future).