### PR TITLE
fix: preserve transaction filters when navigating between ticks

### DIFF
--- a/src/pages/network/tick/components/TickDetails.tsx
+++ b/src/pages/network/tick/components/TickDetails.tsx
@@ -35,8 +35,8 @@ export default function TickDetails({ tick }: Props) {
   const handleTickNavigation = useCallback(
     (direction: 'previous' | 'next') => () => {
       const newTick = Number(tick) + (direction === 'previous' ? -1 : 1)
-      const tab = searchParams.get('tab')
-      navigate(`${Routes.NETWORK.TICK(newTick)}${tab ? `?tab=${tab}` : ''}`)
+      const queryString = searchParams.toString()
+      navigate(`${Routes.NETWORK.TICK(newTick)}${queryString ? `?${queryString}` : ''}`)
     },
     [navigate, tick, searchParams]
   )


### PR DESCRIPTION
Prev/next arrow navigation on the tick page was only forwarding the `tab` query param, stripping filter params (source, destination, amountMin/Max, amountPreset, inputTypeMin/Max) introduced by the URL-synced filters change. Forward the full query string so filters survive tick navigation.