### PR TITLE
fix(events): show processor-lag message when events return silent empty

### DIFF
--- a/src/pages/network/TxPage.tsx
+++ b/src/pages/network/TxPage.tsx
@@ -153,10 +153,9 @@ function RegularTxContent({ txId }: { txId: string }) {
     total,
     isLoading: isEventsLoading,
     hasError: hasEventsError,
-    lastProcessedTick: eventsLastProcessedTick
+    lastProcessedTick: eventsLastProcessedTick,
+    validForTick: eventsValidForTick
   } = useTransactionEvents(txId)
-
-  const eventsErrorMessage = getEventsErrorMessage(hasEventsError, eventsLastProcessedTick, t)
 
   const {
     data: tx,
@@ -167,6 +166,20 @@ function RegularTxContent({ txId }: { txId: string }) {
   } = useGetTransactionByHashQuery(txId, {
     skip: !txId
   })
+
+  const isEventsProcessorBehind =
+    !hasEventsError &&
+    !isEventsLoading &&
+    total === 0 &&
+    tx !== undefined &&
+    eventsValidForTick !== null &&
+    eventsValidForTick < tx.tickNumber
+
+  const eventsErrorMessage = isEventsProcessorBehind
+    ? t('tickNotYetProcessedEvents', {
+        lastProcessedTick: (eventsValidForTick as number).toLocaleString()
+      })
+    : getEventsErrorMessage(hasEventsError, eventsLastProcessedTick, t)
 
   const isLoading = isFetching
   const isInvalidFormat =

--- a/src/pages/network/TxPage.tsx
+++ b/src/pages/network/TxPage.tsx
@@ -20,7 +20,7 @@ import { formatDate, formatEllipsis } from '@app/utils'
 import { CardItem, HomeLink, SubCardItem, TickLink, TxItem, WaitingForTick } from './components'
 import TransactionEvents from './components/TxItem/TransactionEvents'
 import { useTickWatcher, useTransactionEvents } from './hooks'
-import { getEventsErrorMessage } from './utils/filterUtils'
+import { getEventsErrorMessage, getProcessorLagMessage } from './utils/filterUtils'
 
 const VIRTUAL_TX_TYPE_LABELS: Record<number, string> = {
   2: 'Smart Contract Begin Epoch',
@@ -61,6 +61,7 @@ function VirtualTxContent({ txId, virtualTx }: { txId: string; virtualTx: Parsed
   )
 
   const lastProcessedTick = isError ? getLastProcessedTickFromEventsError(error) : null
+  const validForTick = data?.validForTick
 
   if (isFetching && events.length === 0) return <LinearProgress />
   if (isError) {
@@ -68,14 +69,15 @@ function VirtualTxContent({ txId, virtualTx }: { txId: string; virtualTx: Parsed
       <ErrorFallback
         message={
           lastProcessedTick !== null
-            ? t('tickNotYetProcessedEvents', {
-                lastProcessedTick: lastProcessedTick.toLocaleString()
-              })
+            ? getProcessorLagMessage(lastProcessedTick, t)
             : t('virtualTransactionNotFound')
         }
         hideErrorHeader
       />
     )
+  }
+  if (total === 0 && validForTick !== undefined && validForTick < virtualTx.tickNumber) {
+    return <ErrorFallback message={getProcessorLagMessage(validForTick, t)} hideErrorHeader />
   }
 
   return (
@@ -175,11 +177,10 @@ function RegularTxContent({ txId }: { txId: string }) {
     eventsValidForTick !== null &&
     eventsValidForTick < tx.tickNumber
 
-  const eventsErrorMessage = isEventsProcessorBehind
-    ? t('tickNotYetProcessedEvents', {
-        lastProcessedTick: (eventsValidForTick as number).toLocaleString()
-      })
-    : getEventsErrorMessage(hasEventsError, eventsLastProcessedTick, t)
+  const eventsErrorMessage =
+    isEventsProcessorBehind && eventsValidForTick !== null
+      ? getProcessorLagMessage(eventsValidForTick, t)
+      : getEventsErrorMessage(hasEventsError, eventsLastProcessedTick, t)
 
   const isLoading = isFetching
   const isInvalidFormat =

--- a/src/pages/network/event-detail/EventDetailPage.tsx
+++ b/src/pages/network/event-detail/EventDetailPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@app/store/apis/events'
 import { formatDate, formatString } from '@app/utils'
 import { AddressLink, HomeLink, SubCardItem, TickLink, TxLink, VirtualTxLink } from '../components'
+import { getProcessorLagMessage } from '../utils/filterUtils'
 
 function EventDetailPage() {
   const { t } = useTranslation('network-page')
@@ -59,6 +60,7 @@ function EventDetailPage() {
   )
 
   const lastProcessedTick = isError ? getLastProcessedTickFromEventsError(error) : null
+  const validForTick = data?.validForTick
 
   if (isFetching) return <LinearProgress />
   if (isError) {
@@ -66,16 +68,19 @@ function EventDetailPage() {
       <ErrorFallback
         message={
           lastProcessedTick !== null
-            ? t('tickNotYetProcessedEvents', {
-                lastProcessedTick: lastProcessedTick.toLocaleString()
-              })
+            ? getProcessorLagMessage(lastProcessedTick, t)
             : t('eventsLoadFailed')
         }
         hideErrorHeader
       />
     )
   }
-  if (!event) return <ErrorFallback message={t('eventNotFound')} hideErrorHeader />
+  if (!event) {
+    if (validForTick !== undefined && validForTick < tickNumber) {
+      return <ErrorFallback message={getProcessorLagMessage(validForTick, t)} hideErrorHeader />
+    }
+    return <ErrorFallback message={t('eventNotFound')} hideErrorHeader />
+  }
 
   return (
     <PageLayout>

--- a/src/pages/network/hooks/useTransactionEvents.ts
+++ b/src/pages/network/hooks/useTransactionEvents.ts
@@ -11,6 +11,7 @@ export default function useTransactionEvents(txId: string): {
   isLoading: boolean
   hasError: boolean
   lastProcessedTick: number | null
+  validForTick: number | null
 } {
   const page = useValidatedPage()
   const pageSize = useValidatedPageSize()
@@ -30,6 +31,7 @@ export default function useTransactionEvents(txId: string): {
     total,
     isLoading: isFetching,
     hasError: isError,
-    lastProcessedTick: isError ? getLastProcessedTickFromEventsError(error) : null
+    lastProcessedTick: isError ? getLastProcessedTickFromEventsError(error) : null,
+    validForTick: data?.validForTick ?? null
   }
 }

--- a/src/pages/network/tick/components/TickEvents.tsx
+++ b/src/pages/network/tick/components/TickEvents.tsx
@@ -4,7 +4,7 @@ import BetaBanner from '../../components/BetaBanner'
 import { EventsFilterBar } from '../../components/filters'
 import TransactionEvents from '../../components/TxItem/TransactionEvents'
 import { useEventFilters } from '../../hooks'
-import { getEventsErrorMessage } from '../../utils/filterUtils'
+import { getEventsErrorMessage, getProcessorLagMessage } from '../../utils/filterUtils'
 import { useTickEvents } from '../hooks'
 
 type Props = Readonly<{
@@ -22,10 +22,17 @@ export default function TickEvents({ tick }: Props) {
     amountFilter,
     isLoading,
     hasError,
-    lastProcessedTick
+    lastProcessedTick,
+    validForTick
   } = useTickEvents(tick)
 
-  const errorMessage = getEventsErrorMessage(hasError, lastProcessedTick, t)
+  const isEventsProcessorBehind =
+    !hasError && !isLoading && total === 0 && validForTick !== null && validForTick < tick
+
+  const errorMessage =
+    isEventsProcessorBehind && validForTick !== null
+      ? getProcessorLagMessage(validForTick, t)
+      : getEventsErrorMessage(hasError, lastProcessedTick, t)
 
   const filters = useEventFilters({
     eventTypes,

--- a/src/pages/network/tick/hooks/useTickEvents.ts
+++ b/src/pages/network/tick/hooks/useTickEvents.ts
@@ -31,6 +31,7 @@ export default function useTickEvents(tick: number): {
   isLoading: boolean
   hasError: boolean
   lastProcessedTick: number | null
+  validForTick: number | null
   refetch: () => void
 } {
   const [searchParams] = useSearchParams()
@@ -83,6 +84,7 @@ export default function useTickEvents(tick: number): {
     isLoading: isFetching,
     hasError: isError,
     lastProcessedTick: isError ? getLastProcessedTickFromEventsError(error) : null,
+    validForTick: data?.validForTick ?? null,
     refetch
   }
 }

--- a/src/pages/network/utils/filterUtils.ts
+++ b/src/pages/network/utils/filterUtils.ts
@@ -110,6 +110,13 @@ export function parseFilterApiError(error: string | null): ParsedApiError | null
   return null
 }
 
+export function getProcessorLagMessage(
+  lastProcessedTick: number,
+  t: (key: string, params?: Record<string, string>) => string
+): string {
+  return t('tickNotYetProcessedEvents', { lastProcessedTick: lastProcessedTick.toLocaleString() })
+}
+
 /**
  * Builds an error message for events that failed to load.
  * Returns a tick-specific message when lastProcessedTick is available,
@@ -122,7 +129,7 @@ export function getEventsErrorMessage(
 ): string | null {
   if (!hasError) return null
   return lastProcessedTick !== null
-    ? t('tickNotYetProcessedEvents', { lastProcessedTick: lastProcessedTick.toLocaleString() })
+    ? getProcessorLagMessage(lastProcessedTick, t)
     : t('eventsLoadFailed')
 }
 


### PR DESCRIPTION
The events backend can return `200 OK` with an empty `events` list and a `validForTick` value that's still behind the requested tick — i.e. the processor hasn't reached that tick yet. Previously this surfaced as "No events" / "Event not found" / "Virtual transaction not found", incorrectly implying the events didn't exist.

The `tickNotYetProcessedEvents` message was already shown when the backend returned a gRPC code-9 error. This change extends it to the silent-empty case (`200 OK + empty events + validForTick < expectedTick`) — same meaning to the user, same message.

## Screens affected

- Transaction details (regular tx) — `RegularTxContent`
- Transaction details (virtual tx) — `VirtualTxContent`
- Event details — `EventDetailPage`
- Tick details (events tab) — `TickEvents`