### PR TITLE
fix(tick-page): show epoch and placeholders for empty ticks

### DIFF
--- a/src/pages/network/tick/components/TickDetails.tsx
+++ b/src/pages/network/tick/components/TickDetails.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@app/assets/icons'
 import { Alert, Skeleton } from '@app/components/ui'
+import { useGetEpochForTick } from '@app/hooks'
 import { Routes } from '@app/router'
 import {
   useGetComputorListsForEpochQuery,
@@ -27,6 +28,9 @@ export default function TickDetails({ tick }: Props) {
     isFetching: isTickDataLoading,
     error: tickDataError
   } = useGetTickDataQuery(tick, { skip: !tick })
+
+  const { epoch: derivedEpoch, isLoading: isEpochLoading } = useGetEpochForTick(tick)
+  const epoch = tickData?.epoch ?? derivedEpoch
 
   const { data: computorLists } = useGetComputorListsForEpochQuery(tickData?.epoch ?? 0, {
     skip: !tick || !tickData?.epoch
@@ -98,10 +102,10 @@ export default function TickDetails({ tick }: Props) {
             title={t('epoch')}
             variant="secondary"
             content={
-              isTickDataLoading ? (
+              isTickDataLoading || (epoch === undefined && isEpochLoading) ? (
                 <Skeleton className="h-16 w-64 rounded-8" />
               ) : (
-                <p className="font-space text-sm text-gray-50">{tickData?.epoch}</p>
+                <p className="font-space text-sm text-gray-50">{epoch ?? '-'}</p>
               )
             }
           />
@@ -112,7 +116,9 @@ export default function TickDetails({ tick }: Props) {
               isTickDataLoading ? (
                 <Skeleton className="h-40 rounded-8 sm:h-20" />
               ) : (
-                <p className="break-all font-space text-sm text-gray-50">{tickData?.signature}</p>
+                <p className="break-all font-space text-sm text-gray-50">
+                  {tickData?.signature || '-'}
+                </p>
               )
             }
           />
@@ -123,7 +129,10 @@ export default function TickDetails({ tick }: Props) {
               isTickDataLoading ? (
                 <Skeleton className="h-40 rounded-8 sm:h-20" />
               ) : (
-                tickLeader && <AddressLink value={tickLeader} copy />
+                <>
+                  {tickLeader && <AddressLink value={tickLeader} copy />}
+                  {!tickLeader && <p className="font-space text-sm text-gray-50">-</p>}
+                </>
               )
             }
           />

--- a/src/pages/network/tick/components/TickDetails.tsx
+++ b/src/pages/network/tick/components/TickDetails.tsx
@@ -32,9 +32,10 @@ export default function TickDetails({ tick }: Props) {
   const { epoch: derivedEpoch, isLoading: isEpochLoading } = useGetEpochForTick(tick)
   const epoch = tickData?.epoch ?? derivedEpoch
 
-  const { data: computorLists } = useGetComputorListsForEpochQuery(tickData?.epoch ?? 0, {
-    skip: !tick || !tickData?.epoch
-  })
+  const { data: computorLists, isFetching: isComputorListsLoading } =
+    useGetComputorListsForEpochQuery(epoch ?? 0, {
+      skip: !tick || !epoch
+    })
 
   const handleTickNavigation = useCallback(
     (direction: 'previous' | 'next') => () => {
@@ -105,7 +106,7 @@ export default function TickDetails({ tick }: Props) {
               isTickDataLoading || (epoch === undefined && isEpochLoading) ? (
                 <Skeleton className="h-16 w-64 rounded-8" />
               ) : (
-                <p className="font-space text-sm text-gray-50">{epoch ?? '-'}</p>
+                <p className="font-space text-sm text-gray-50">{epoch || '-'}</p>
               )
             }
           />
@@ -126,7 +127,7 @@ export default function TickDetails({ tick }: Props) {
             title={t('tickLeader')}
             variant="secondary"
             content={
-              isTickDataLoading ? (
+              isTickDataLoading || isComputorListsLoading ? (
                 <Skeleton className="h-40 rounded-8 sm:h-20" />
               ) : (
                 <>


### PR DESCRIPTION
Empty ticks return null tick data, leaving the epoch field blank and the signature / tick-leader cards rendering as empty rows. Derive the epoch from the processed tick intervals (already cached in Redux) so it shows even when there's no tick data, and render "-" for the signature and tick-leader fields when the underlying value is missing.