### PR TITLE
ci: workflow hardening + gated prod deploy + SSH release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS — reviewed by the workflow-security group for high-risk paths.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# The workflow-security group reviews CI/CD attack surface. Domain reviewers
+# provide functional review via a separate CODEOWNERS entry per repo.
+
+# Workflow files and composite actions — mandatory review by workflow-security.
+/.github/workflows/         @qubic/workflow-security
+/.github/actions/           @qubic/workflow-security
+/.github/CODEOWNERS         @qubic/workflow-security
+
+# Repository-level automation config — mandatory review by workflow-security.
+/.github/dependabot.yml     @qubic/workflow-security

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,21 +10,31 @@ on:
       - reopened
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only: this workflow only validates commit messages.
+permissions:
+  contents: read
+
 jobs:
   commitlint:
+    name: Commitlint
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # Fetches the full history so that all commit SHAs are available for commitlint
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
@@ -44,4 +54,7 @@ jobs:
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,13 @@ jobs:
       issues: write # semantic-release comments on released issues
       pull-requests: write # semantic-release comments on released PRs
     steps:
-      # persist-credentials is intentionally left enabled (the default) so that
-      # semantic-release can push the release commit + tag via GITHUB_TOKEN.
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 # zizmor: ignore[artipacked]
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # Fetch full commit history
+          # Kept enabled so semantic-release can push the release commit + tag
+          # via GITHUB_TOKEN.
+          persist-credentials: true # zizmor: ignore[artipacked]
 
       - name: ⚙️ Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,20 +21,23 @@ concurrency:
 permissions: {}
 
 jobs:
-  release-and-deploy:
-    name: Release and deploy
+  build:
+    name: Release and build
     runs-on: ubuntu-latest
     permissions:
       contents: write # semantic-release pushes the release commit + tag
       issues: write # semantic-release comments on released issues
       pull-requests: write # semantic-release comments on released PRs
     steps:
+      # Checkout over SSH using the release deploy key. `main` is protected by a
+      # ruleset that requires PRs, but the deploy key is on the ruleset bypass
+      # list — so semantic-release can push the release commit + tag directly.
+      # persist-credentials stays enabled so that SSH push works.
       - name: 🛎️ Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 0 # Fetch full commit history
-          # Kept enabled so semantic-release can push the release commit + tag
-          # via GITHUB_TOKEN.
+          fetch-depth: 0 # Fetch full commit history (semantic-release needs it)
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
           persist-credentials: true # zizmor: ignore[artipacked]
 
       - name: ⚙️ Setup pnpm
@@ -69,6 +72,29 @@ jobs:
             }}
           VITE_TURNSTILE_SITE_KEY: ${{ secrets.TURNSTILE_SITE_KEY }}
         run: pnpm run build
+
+      - name: 📦 Upload build artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    # Gate production only: `main` uses the protected `production` environment
+    # (required reviewers + prevent self-review), so a prod deploy waits for a
+    # manual approval. Other branches use their own ungated environments.
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref_name }}
+    steps:
+      - name: 📥 Download build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
 
       - name: 📤 Deploy to the corresponding environment
         uses: SamKirkland/FTP-Deploy-Action@cfcb39fa3cdf2ff98ac1a7fbfa539d20526d474d # 4.3.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,11 @@
 name: 🚀 Release and Deploy
 
 on:
+  # Only `push` — a merged PR already produces a push to the target branch, so
+  # merges still deploy exactly once. Closing a PR *without* merging changes no
+  # ref, so it produces no push and (correctly) does not deploy. Listening to
+  # `pull_request: closed` as well would deploy every merge twice.
   push:
-    branches:
-      - dev
-      - staging
-      - main
-      - testnet
-  pull_request:
-    types:
-      - closed
     branches:
       - dev
       - staging
@@ -32,8 +28,6 @@ jobs:
       contents: write # semantic-release pushes the release commit + tag
       issues: write # semantic-release comments on released issues
       pull-requests: write # semantic-release comments on released PRs
-    # Only run on push events OR on merged pull requests (not closed-without-merge)
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
       # persist-credentials is intentionally left enabled (the default) so that
       # semantic-release can push the release commit + tag via GITHUB_TOKEN.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,22 +16,37 @@ on:
       - main
       - testnet
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Do not cancel an in-progress deploy; let it finish to avoid partial uploads.
+  cancel-in-progress: false
+
+# Secure default: no permissions unless a job opts in below.
+permissions: {}
+
 jobs:
   release-and-deploy:
+    name: Release and deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # semantic-release pushes the release commit + tag
+      issues: write # semantic-release comments on released issues
+      pull-requests: write # semantic-release comments on released PRs
     # Only run on push events OR on merged pull requests (not closed-without-merge)
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
+      # persist-credentials is intentionally left enabled (the default) so that
+      # semantic-release can push the release commit + tag via GITHUB_TOKEN.
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0 # Fetch full commit history
 
       - name: ⚙️ Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: 🔧 Set up Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
@@ -61,7 +76,7 @@ jobs:
         run: pnpm run build
 
       - name: 📤 Deploy to the corresponding environment
-        uses: SamKirkland/FTP-Deploy-Action@4.3.3
+        uses: SamKirkland/FTP-Deploy-Action@cfcb39fa3cdf2ff98ac1a7fbfa539d20526d474d # 4.3.3
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: |

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -11,13 +11,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
+# Read-only by default; the job elevates only what it needs.
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: read # read PR metadata (title) to validate it
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,39 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e # v1.73.0
+        with:
+          fail_on_error: true
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        with:
+          persona: auditor

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,23 +12,33 @@ on:
       - staging
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only: lint/format checks need no write access.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      actions: 'read'
+      contents: 'read' # read source to lint
+      actions: 'read' # read Actions metadata for the pnpm cache
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'

--- a/.releaserc
+++ b/.releaserc
@@ -26,7 +26,7 @@
           "CHANGELOG.md",
           "package.json"
         ],
-        "message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
> **⚠️ Note:** This PR **supersedes #497** — it already contains **everything** from that PR (CODEOWNERS, workflow linting, and the hardening) **plus** the release/deploy changes below. **#497 can be closed.**

## Security hardening (from #497)
- CODEOWNERS routing `.github/**` to `@qubic/workflow-security`
- `lint-workflows` workflow (actionlint + zizmor auditor)
- All third-party actions pinned to commit SHAs, least-privilege `permissions`, `concurrency` guards and job names across commitlint / lint / lint-pr / deploy

## Releases under the new `main` ruleset
- `main` now requires PRs, which would block semantic-release's direct push. Checkout now uses an **SSH deploy key** (on the ruleset bypass list) so the release commit + tag still land on `main`.
- `[skip ci]` added to the release commit so it does not re-trigger the workflow.

## Gated production deploys
- Workflow split into `build` + `deploy` jobs.
- `deploy` uses the `production` environment (required reviewers + prevent self-review) for `main`, so a production deploy waits for a manual approval. Other branches deploy through their own ungated environments.

## Deploy-once fix
- Removed the redundant `pull_request: closed` trigger so a merge deploys exactly once; closing a PR without merging still does not deploy.
